### PR TITLE
fix: remove images from extension package

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -22,3 +22,5 @@ test
 patches
 .wdio-vscode-service
 .releaserc.json
+images/**/*
+!images/icon.png


### PR DESCRIPTION
## Proposed Changes

When the package is produced, relative image urls in the readme are rewritten to github absolute paths. As a result those images don't need to be included in the extension package.
