### PR TITLE
[DRAFT] feat: puya debugging support; improved source map management 

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -10,3 +10,4 @@ coverage
 **/generated/types.ts
 # don't format ide files
 .idea
+**/*sources.avm.json

--- a/examples/multiRootWorkspace/puya/.algokit/sources/contract/HelloWorld.approval.puya.map
+++ b/examples/multiRootWorkspace/puya/.algokit/sources/contract/HelloWorld.approval.puya.map
@@ -1,0 +1,43 @@
+{
+ "version": 3,
+ "sources": [
+  "/Users/aorumbayev/MakerX/projects/puya-debugger/algokit-avm-vscode-debugger/examples/multiRootWorkspace/puya/.algokit/sources/contract/contract.py",
+  "/algopy/arc4.py"
+ ],
+ "names": [
+  "!",
+  "assert",
+  "bz __puya_arc4_router___after_if_else@7",
+  "callsub __puya_arc4_router__",
+  "callsub hello",
+  "callsub initialize",
+  "concat",
+  "dup",
+  "err",
+  "extract 2 0",
+  "extract 6 2",
+  "frame_dig -1",
+  "intc 0",
+  "intc 1",
+  "intcblock 0 1",
+  "itob",
+  "len",
+  "log",
+  "match __puya_arc4_router___initialize_route@2 __puya_arc4_router___hello_route@3",
+  "proto 0 0",
+  "proto 0 1",
+  "proto 1 1",
+  "pushbytes 151f7c75",
+  "pushbytes 48656c6c6f2c20",
+  "pushbytess fd2c93cd 02bece11",
+  "retsub",
+  "return",
+  "swap",
+  "txn ApplicationID",
+  "txn NumAppArgs",
+  "txn OnCompletion",
+  "txna ApplicationArgs 0",
+  "txna ApplicationArgs 1"
+ ],
+ "mappings": "AAAAc;AAAAA;AAAAA;AAAAA;AAAAA;ACFAX;AAAAA;AAAAA;AAAAuB;ADYAN;AAAAA;AAAAA;AAAAS;AAAAA;AAAA3B;AAAAA;AAAAA;AAAAsB;AAAAA;AAAAA;AAAAA;AAAAA;AAAAA;AAAAA;AAAAA;AAAAA;AAAAA;AAAAA;AAAAA;AAAAO;AAAAA;AAAAA;AAAAb;AAAAA;AAAAA;AAAAA;AAAAA;AAAAA;AAAAN;AAAAa;AACAK;AAAAA;AAAA9B;AAAAC;AAAA2B;AAAAA;AAAA5B;AAAAC;AAAAI;AAAAA;AAAAA;AAAAQ;AAAAY;AAIAK;AAAAA;AAAA9B;AAAAC;AAAA2B;AAAAA;AAAA3B;AALA+B;AAAAA;AAAAA;AAAAvB;AAAAA;AAAAA;AAKAL;AAAAA;AAAAA;AAAAG;AAAAS;AAAAD;AAAAL;AAAAA;AAAAA;AAAAiB;AAAArB;AAAAgB;AAAAA;AAAAA;AAAAA;AAAAA;AAAAA;AAAAK;AAAArB;AAAAW;AAAAJ;AAAAY;AALAb;AAAAa;AACAN;AAAAA;AAAAA;AAEAX;AAEAa;AAAAA;AAAAA;AAEAE;AAAAA;AAAAA;AAAAA;AAAAA;AAAAA;AAAAA;AAAAA;AAAAA;AAAAZ;AAAAA;AAAAL;AAAAmB"
+}

--- a/examples/multiRootWorkspace/puya/.algokit/sources/contract/contract.py
+++ b/examples/multiRootWorkspace/puya/.algokit/sources/contract/contract.py
@@ -1,0 +1,19 @@
+from algopy import ARC4Contract, String, arc4, op
+from algopy.arc4 import abimethod
+
+
+class ListingKey(arc4.Struct, kw_only=True):
+    owner: arc4.Address
+    asset: arc4.UInt64
+    nonce: arc4.UInt64
+
+
+class HelloWorld(ARC4Contract):
+    @abimethod(create="require")
+    def initialize(self) -> None:
+        op.err()
+
+    @abimethod()
+    def hello(self, name: String) -> String:
+        return "Hello, " + name
+

--- a/examples/multiRootWorkspace/puya/.algokit/sources/sources.avm.json
+++ b/examples/multiRootWorkspace/puya/.algokit/sources/sources.avm.json
@@ -1,0 +1,8 @@
+{
+  "txn-group-sources": [
+    {
+      "sourcemap-location": "./contract/HelloWorld.approval.bin.map",
+      "hash": "bpraJf7C/G0trk7LMjZwUyO2nRquR4vOGEzujlnkWpw="
+    }
+  ]
+}

--- a/examples/multiRootWorkspace/puya/debug_traces/puya-simulate-response.trace.avm.json
+++ b/examples/multiRootWorkspace/puya/debug_traces/puya-simulate-response.trace.avm.json
@@ -1,0 +1,158 @@
+{
+  "eval-overrides": {
+    "allow-empty-signatures": true,
+    "max-log-calls": 2048,
+    "max-log-size": 65536
+  },
+  "exec-trace-config": {
+    "enable": true,
+    "scratch-change": true,
+    "stack-change": true
+  },
+  "last-round": 4,
+  "txn-groups": [
+    {
+      "app-budget-added": 700,
+      "app-budget-consumed": 18,
+      "failed-at": [0],
+      "failure-message": "transaction N2Q3RLJEBRKFO7FTRTEDR2FF7632VQXRF62PUY3VFO5GK4YW4GGA: logic eval error: err opcode executed. Details: app=1005, pc=93, opcodes=retsub; label5:; proto 0 0; err; label6:",
+      "txn-results": [
+        {
+          "app-budget-consumed": 18,
+          "exec-trace": {
+            "approval-program-hash": "bpraJf7C/G0trk7LMjZwUyO2nRquR4vOGEzujlnkWpw=",
+            "approval-program-trace": [
+              {
+                "pc": 1
+              },
+              {
+                "pc": 5
+              },
+              {
+                "pc": 9
+              },
+              {
+                "pc": 12,
+                "stack-additions": [
+                  {
+                    "type": 2,
+                    "uint": 1
+                  }
+                ]
+              },
+              {
+                "pc": 14,
+                "stack-pop-count": 1
+              },
+              {
+                "pc": 17,
+                "stack-additions": [
+                  {
+                    "bytes": "/SyTzQ==",
+                    "type": 1
+                  }
+                ]
+              },
+              {
+                "pc": 23,
+                "stack-additions": [
+                  {
+                    "bytes": "Ar7OEQ==",
+                    "type": 1
+                  }
+                ]
+              },
+              {
+                "pc": 29,
+                "stack-additions": [
+                  {
+                    "bytes": "/SyTzQ==",
+                    "type": 1
+                  }
+                ]
+              },
+              {
+                "pc": 32,
+                "stack-pop-count": 3
+              },
+              {
+                "pc": 40,
+                "stack-additions": [
+                  {
+                    "type": 2
+                  }
+                ]
+              },
+              {
+                "pc": 42,
+                "stack-additions": [
+                  {
+                    "type": 2,
+                    "uint": 1
+                  }
+                ],
+                "stack-pop-count": 1
+              },
+              {
+                "pc": 43,
+                "stack-pop-count": 1
+              },
+              {
+                "pc": 44,
+                "stack-additions": [
+                  {
+                    "type": 2
+                  }
+                ]
+              },
+              {
+                "pc": 46,
+                "stack-additions": [
+                  {
+                    "type": 2,
+                    "uint": 1
+                  }
+                ],
+                "stack-pop-count": 1
+              },
+              {
+                "pc": 47,
+                "stack-pop-count": 1
+              },
+              {
+                "pc": 48
+              },
+              {
+                "pc": 90
+              },
+              {
+                "pc": 93
+              }
+            ]
+          },
+          "txn-result": {
+            "application-index": 1005,
+            "pool-error": "",
+            "txn": {
+              "sig": "nfzztc23IP5TZuYsdlqUT1zjlJPcqITml6yziw2LPvgwn1oPUlL9a4pB0iTldAm5tOg9RFjIPDBSDSFE1d8nDg==",
+              "txn": {
+                "apaa": ["/SyTzQ=="],
+                "apap": "CiACAAGIAAFDigABMRtBAEeABP0sk82ABAK+zhE2GgCOAgACAA8iiTEZFEQxGBREiAAnI4kxGRREMRhENhoBVwIAiAAZSRUWVwYCTFCABBUffHVMULAjiSKJigAAAIoBAYAHSGVsbG8sIIv/UIk=",
+                "apsu": "CoEBQw==",
+                "fee": 1000,
+                "fv": 4,
+                "gen": "dockernet-v1",
+                "gh": "wUURMeXWH8dw9TePRCmmKMMD17IfBRh4fApXf3tCIBE=",
+                "lv": 1004,
+                "note": "QUxHT0tJVF9ERVBMT1lFUjpqeyJuYW1lIjogIkhlbGxvV29ybGQiLCAidmVyc2lvbiI6ICJ2MS4xIiwgImRlbGV0YWJsZSI6IG51bGwsICJ1cGRhdGFibGUiOiBudWxsfQ==",
+                "snd": "FVKDNHI2CFGCXBRIRF5VQIJG3PHH3G6EMU6HAQWUHOCTCIWVPHXH2DHL5M",
+                "type": "appl"
+              }
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "version": 2
+}

--- a/examples/multiRootWorkspace/sample.code-workspace
+++ b/examples/multiRootWorkspace/sample.code-workspace
@@ -2,29 +2,29 @@
   "folders": [
     {
       "path": "./",
-      "name": "ROOT"
+      "name": "ROOT",
     },
     {
-      "path": "./app-state-changes"
+      "path": "./app-state-changes",
     },
     {
-      "path": "./errors"
+      "path": "./errors",
     },
     {
-      "path": "./recursive-app"
+      "path": "./recursive-app",
     },
     {
-      "path": "./slot-machine"
+      "path": "./slot-machine",
     },
     {
-      "path": "./sourcemap-test"
+      "path": "./sourcemap-test",
     },
     {
-      "path": "./stack-scratch"
+      "path": "./stack-scratch",
     },
     {
-      "path": "./stepping-test"
-    }
+      "path": "./stepping-test",
+    },
   ],
   "settings": {
     "files.exclude": {
@@ -34,8 +34,8 @@
       "slot-machine/": true,
       "sourcemap-test/": true,
       "stack-scratch/": true,
-      "stepping-test/": true
-    }
+      "stepping-test/": true,
+    },
     // "avmDebugger.debugAdapter.port": 4711 // Uncomment to debug the AVM debugger/debug adapter by running the "Server" launch configuration found in https://github.com/algorand/avm-debugger
-  }
+  },
 }

--- a/examples/workspace/.algokit/sources/sources.avm.json
+++ b/examples/workspace/.algokit/sources/sources.avm.json
@@ -1,12 +1,16 @@
 {
   "txn-group-sources": [
     {
-      "sourcemap-location": "./slot-machine/slot-machine.teal.tok.map",
-      "hash": "AYqVv/i0Y88cebp0m1MAYE9gk/1SnhFm8oLKOBMOKac="
-    },
-    {
       "sourcemap-location": "./slot-machine/fake-random.teal.tok.map",
       "hash": "88rrCGDJdARk4rasK5FN8BzmKTqHW5WRzYiRWmtA7HY="
+    },
+    {
+      "sourcemap-location": null,
+      "hash": "nN5LNX4rlRXfN0ax9hH0TsYh1XDhOSLnANPnrWSdATw="
+    },
+    {
+      "sourcemap-location": "slot-machine/slot-machine.teal.tok.map",
+      "hash": "AYqVv/i0Y88cebp0m1MAYE9gk/1SnhFm8oLKOBMOKac="
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "algosdk": "^2.9.0",
-        "avm-debug-adapter": "^0.2.0",
+        "avm-debug-adapter": "file:../af-avm-debugger/out/avm-debug-adapter-0.2.0.tgz",
         "lodash": "^4.17.21"
       },
       "devDependencies": {
@@ -3960,6 +3960,12 @@
         "ieee754": "^1.2.1"
       }
     },
+    "node_modules/algosdk/node_modules/js-sha512": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/js-sha512/-/js-sha512-0.8.0.tgz",
+      "integrity": "sha512-PWsmefG6Jkodqt+ePTvBZCSMFgN7Clckjd0O7su3I0+BW2QWUTJNzjktHsztGLhncP2h8mcF9V9Y2Ha59pAViQ==",
+      "license": "MIT"
+    },
     "node_modules/ansi-colors": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
@@ -4369,8 +4375,9 @@
     },
     "node_modules/avm-debug-adapter": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/avm-debug-adapter/-/avm-debug-adapter-0.2.0.tgz",
-      "integrity": "sha512-DYmtMMZRYLSJ5jXEriYUIky6cqO0K1DzxXi2EtVeYz9EwF10NqvWDDgtLZvyhjkvzxF5NHvbYfpFQn6zgnBp0Q==",
+      "resolved": "file:../af-avm-debugger/out/avm-debug-adapter-0.2.0.tgz",
+      "integrity": "sha512-hG98vGQ20Vze1ybEsfiCZYg5WY7HWXtULDDGMatP7t80xJShjE+nAygf9o6iik7qQQuJcTNoABI2XmAb1SlLAA==",
+      "license": "MIT",
       "dependencies": {
         "@vscode/debugadapter": "^1.64.0",
         "algosdk": "^3.0.0-beta.1",
@@ -4400,6 +4407,12 @@
       "engines": {
         "node": ">=18.0.0"
       }
+    },
+    "node_modules/avm-debug-adapter/node_modules/js-sha512": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/js-sha512/-/js-sha512-0.8.0.tgz",
+      "integrity": "sha512-PWsmefG6Jkodqt+ePTvBZCSMFgN7Clckjd0O7su3I0+BW2QWUTJNzjktHsztGLhncP2h8mcF9V9Y2Ha59pAViQ==",
+      "license": "MIT"
     },
     "node_modules/avvio": {
       "version": "8.3.0",
@@ -10082,11 +10095,6 @@
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
       "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
-    },
-    "node_modules/js-sha512": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/js-sha512/-/js-sha512-0.8.0.tgz",
-      "integrity": "sha512-PWsmefG6Jkodqt+ePTvBZCSMFgN7Clckjd0O7su3I0+BW2QWUTJNzjktHsztGLhncP2h8mcF9V9Y2Ha59pAViQ=="
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -195,6 +195,16 @@
         "category": "AlgoKit AVM Debug",
         "enablement": "!inDebugMode",
         "icon": "$(debug-alt)"
+      },
+      {
+        "command": "extension.avmDebugger.clearAvmDebugRegistry",
+        "title": "Clear AVM Debug Registry",
+        "category": "AlgoKit AVM Debug"
+      },
+      {
+        "command": "extension.avmDebugger.editAvmDebugRegistry",
+        "title": "Edit AVM Debug Registry",
+        "category": "AlgoKit AVM Debug"
       }
     ],
     "configuration": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "algosdk": "^2.9.0",
-    "avm-debug-adapter": "^0.2.0",
+    "avm-debug-adapter": "file:../af-avm-debugger/out/avm-debug-adapter-0.2.0.tgz",
     "lodash": "^4.17.21"
   },
   "devDependencies": {
@@ -217,6 +217,11 @@
           ],
           "default": null,
           "description": "If specified, the extension will connect to a debug adapter server running on the supplied port. By default the debug adapter will be run inline automatically. This setting should only be used in advanced scenarios."
+        },
+        "avmDebugger.defaultSourcemapRegistryFile": {
+          "type": "string",
+          "default": "",
+          "description": "The default path for the sourcemap registry file. If not set, defaults to '.algokit/sources/sources.avm.json' in the workspace root."
         }
       }
     }

--- a/src/activateAvmDebug.ts
+++ b/src/activateAvmDebug.ts
@@ -1,16 +1,8 @@
-import { take } from 'lodash'
 import * as vscode from 'vscode'
 import { AvmDebugConfigProvider } from './configuration'
-import {
-  MAX_FILES_TO_SHOW,
-  NO_WORKSPACE_ERROR_MESSAGE,
-  SIMULATE_TRACE_FILE_EXTENSION,
-  SIMULATE_TRACE_FILE_PATTERN,
-  SOURCES_FILE_NAME,
-  SOURCES_FILE_PATTERN,
-} from './constants'
+import { SIMULATE_TRACE_FILE_EXTENSION, SIMULATE_TRACE_FILE_PATTERN, SOURCES_FILE_NAME, SOURCES_FILE_PATTERN } from './constants'
 import { workspaceFileAccessor } from './fileAccessor'
-import { findFilesInWorkspace, getFilePathRelativeToClosestWorkspace, workspaceFolderFromPath } from './utils'
+import { findAndPickFile, getWorkspaceFolder, workspaceFolderFromPath } from './utils'
 
 export function activateAvmDebug(context: vscode.ExtensionContext, factory: vscode.DebugAdapterDescriptorFactory) {
   const provider = new AvmDebugConfigProvider()
@@ -19,25 +11,17 @@ export function activateAvmDebug(context: vscode.ExtensionContext, factory: vsco
 
   context.subscriptions.push(
     vscode.commands.registerCommand('extension.avmDebugger.debugOpenTraceFile', async (resource: vscode.Uri) => {
-      let targetResource = resource
-      if (!targetResource && vscode.window.activeTextEditor) {
-        targetResource = vscode.window.activeTextEditor.document.uri
-      }
-      if (targetResource) {
-        const workspaceFolder = vscode.workspace.getWorkspaceFolder(targetResource)
-        if (!workspaceFolder) {
-          vscode.window.showErrorMessage(NO_WORKSPACE_ERROR_MESSAGE)
-          return undefined
-        }
+      const targetResource = resource || vscode.window.activeTextEditor?.document.uri
+      const workspaceFolder = await getWorkspaceFolder(targetResource)
+      if (!workspaceFolder) return
 
-        await vscode.debug.startDebugging(workspaceFolder, {
-          type: 'avm',
-          name: 'Debug AVM Trace File',
-          request: 'launch',
-          simulateTraceFile: targetResource.fsPath,
-          stopOnEntry: true,
-        })
-      }
+      await vscode.debug.startDebugging(workspaceFolder, {
+        type: 'avm',
+        name: 'Debug AVM Trace File',
+        request: 'launch',
+        simulateTraceFile: targetResource?.fsPath,
+        stopOnEntry: true,
+      })
     }),
   )
 
@@ -47,36 +31,17 @@ export function activateAvmDebug(context: vscode.ExtensionContext, factory: vsco
       let sourcesFilePath = config.get<string>('programSourcesDescriptionFile')
 
       if (!sourcesFilePath) {
-        const workspaceFolder = vscode.workspace.workspaceFolders?.[0]
-        if (!workspaceFolder) {
-          vscode.window.showErrorMessage(NO_WORKSPACE_ERROR_MESSAGE)
-          return
-        }
+        const workspaceFolder = await getWorkspaceFolder()
+        if (!workspaceFolder) return
 
-        const sourcesFiles = await findFilesInWorkspace(workspaceFolder, SOURCES_FILE_PATTERN)
-
-        if (sourcesFiles.length === 0) {
-          vscode.window.showErrorMessage(
-            `No program sources description files (with name ${SOURCES_FILE_NAME}) were found in the workspace.`,
-          )
-          return
-        }
-
-        if (sourcesFiles.length === 1) {
-          sourcesFilePath = sourcesFiles[0].fsPath
-        } else {
-          const quickPickItems = sourcesFiles.map((uri) => ({
-            label: getFilePathRelativeToClosestWorkspace(workspaceFolder)(uri),
-            uri,
-          }))
-          const selected = await vscode.window.showQuickPick(quickPickItems, {
-            title: 'Select program sources description file to clear',
-            placeHolder: 'Please select a file to clear',
-          })
-          if (!selected) return
-          sourcesFilePath = selected.uri.fsPath
-        }
+        sourcesFilePath = await findAndPickFile(workspaceFolder, SOURCES_FILE_PATTERN, {
+          title: 'Select program sources description file to clear',
+          placeHolder: 'Please select a file to clear',
+          noFilesErrorMessage: `No program sources description files (with name ${SOURCES_FILE_NAME}) were found in the workspace.`,
+        })
+        if (!sourcesFilePath) return
       }
+
       const confirmation = await vscode.window.showWarningMessage(
         `Are you sure you want to clear the content of ${sourcesFilePath}?`,
         { modal: true },
@@ -99,36 +64,17 @@ export function activateAvmDebug(context: vscode.ExtensionContext, factory: vsco
         const document = await vscode.workspace.openTextDocument(currentFile)
         await vscode.window.showTextDocument(document)
       } else {
-        const workspaceFolder = vscode.workspace.workspaceFolders?.[0]
-        if (!workspaceFolder) {
-          vscode.window.showErrorMessage(NO_WORKSPACE_ERROR_MESSAGE)
-          return
-        }
+        const workspaceFolder = await getWorkspaceFolder()
+        if (!workspaceFolder) return
 
-        const sourcesFiles = await findFilesInWorkspace(workspaceFolder, SOURCES_FILE_PATTERN)
+        const sourcesFilePath = await findAndPickFile(workspaceFolder, SOURCES_FILE_PATTERN, {
+          title: 'Program sources description file',
+          placeHolder: 'Please select a program sources description file',
+          noFilesErrorMessage: `No program sources description files (with name ${SOURCES_FILE_NAME}) were found in the workspace.`,
+        })
+        if (!sourcesFilePath) return
 
-        if (sourcesFiles.length === 0) {
-          vscode.window.showErrorMessage(
-            `No program sources description files (with name ${SOURCES_FILE_NAME}) were found in the workspace.`,
-          )
-          return
-        }
-
-        let defaultPath: vscode.Uri
-        if (sourcesFiles.length === 1) {
-          defaultPath = sourcesFiles[0]
-        } else {
-          const quickPickItems = sourcesFiles.map((uri) => ({
-            label: uri.fsPath,
-            uri,
-          }))
-          const selected = await vscode.window.showQuickPick(quickPickItems, {
-            title: 'Program sources description file',
-            placeHolder: 'Please select a program sources description file',
-          })
-          defaultPath = selected ? selected.uri : sourcesFiles[0]
-        }
-        const document = await vscode.workspace.openTextDocument(defaultPath)
+        const document = await vscode.workspace.openTextDocument(sourcesFilePath)
         await vscode.window.showTextDocument(document)
       }
 
@@ -139,90 +85,28 @@ export function activateAvmDebug(context: vscode.ExtensionContext, factory: vsco
   context.subscriptions.push(
     vscode.commands.registerCommand('extension.avmDebugger.getSimulateTraceFile', async (config) => {
       const workspaceFolder = workspaceFolderFromPath(config.workspaceFolderPath)
-      const traceUris = await findFilesInWorkspace(workspaceFolder, SIMULATE_TRACE_FILE_PATTERN)
-
-      const quickPickItems: vscode.QuickPickItem[] = [
-        { label: 'External Files', kind: vscode.QuickPickItemKind.Separator },
-        { label: 'Browse...', description: 'Select external simulate trace file' },
-      ]
-
-      if (traceUris.length === 0) {
-        vscode.window.showWarningMessage(
-          `No simulate trace files (with extension ${SIMULATE_TRACE_FILE_EXTENSION}) were found in the workspace.`,
-        )
-      } else {
-        if (traceUris.length > MAX_FILES_TO_SHOW) {
-          vscode.window.showInformationMessage(
-            `More than ${MAX_FILES_TO_SHOW} simulate trace files were found in the workspace. Results have been truncated.`,
-          )
-        }
-
-        const getRelativeFilePath = getFilePathRelativeToClosestWorkspace(workspaceFolder)
-        const relativeTraceUris = take(traceUris, MAX_FILES_TO_SHOW).map(getRelativeFilePath)
-
-        quickPickItems.unshift(
-          { label: 'Workspace Files', kind: vscode.QuickPickItemKind.Separator },
-          ...relativeTraceUris.map((uri) => ({ label: uri })),
-        )
-      }
-
-      const selected = await vscode.window.showQuickPick(quickPickItems, {
+      return findAndPickFile(workspaceFolder, SIMULATE_TRACE_FILE_PATTERN, {
         title: 'Simulate trace file',
         placeHolder: 'Please select a simulate trace file to debug or browse for an external file',
+        noFilesErrorMessage: `No simulate trace files (with extension ${SIMULATE_TRACE_FILE_EXTENSION}) were found in the workspace.`,
+        allowBrowse: true,
+        fileType: SIMULATE_TRACE_FILE_EXTENSION,
       })
-
-      if (selected?.label === 'Browse...') {
-        const [file] =
-          (await vscode.window.showOpenDialog({
-            canSelectFiles: true,
-            canSelectFolders: false,
-            canSelectMany: false,
-            filters: { 'Simulate Trace Files': [SIMULATE_TRACE_FILE_EXTENSION.slice(1)] },
-            title: 'Select Simulate Trace File',
-          })) ?? []
-
-        if (file?.fsPath.endsWith(SIMULATE_TRACE_FILE_EXTENSION)) {
-          return file.fsPath
-        } else {
-          vscode.window.showErrorMessage(`Selected file must have the extension *${SIMULATE_TRACE_FILE_EXTENSION}`)
-          return undefined
-        }
-      }
-
-      return selected ? selected.label : undefined
     }),
   )
 
   context.subscriptions.push(
     vscode.commands.registerCommand('extension.avmDebugger.getProgramSourcesDescriptionFile', async (config) => {
       const workspaceFolder = workspaceFolderFromPath(config.workspaceFolderPath)
-      const sourcesUris = await findFilesInWorkspace(workspaceFolder, SOURCES_FILE_PATTERN)
-
-      if (sourcesUris.length === 0) {
-        vscode.window.showErrorMessage(`No program sources description files (with name ${SOURCES_FILE_NAME}) were found in the workspace.`)
-        return undefined
-      }
-
-      if (sourcesUris.length > MAX_FILES_TO_SHOW) {
-        vscode.window.showInformationMessage(
-          `More than ${MAX_FILES_TO_SHOW} simulate trace files were found in the workspace. Results have been truncated.`,
-        )
-      }
-
-      const getRelativeFilePath = getFilePathRelativeToClosestWorkspace(workspaceFolder)
-      const relativeSourcesUris = take(sourcesUris, MAX_FILES_TO_SHOW).map(getRelativeFilePath)
-
-      return await vscode.window.showQuickPick(relativeSourcesUris, {
+      return findAndPickFile(workspaceFolder, SOURCES_FILE_PATTERN, {
         title: 'Program sources description file',
         placeHolder: 'Please select a program sources description file',
-        canPickMany: false,
+        noFilesErrorMessage: `No program sources description files (with name ${SOURCES_FILE_NAME}) were found in the workspace.`,
       })
     }),
   )
 
   if (isDisposable(factory)) {
-    // https://vscode-docs.readthedocs.io/en/stable/extensions/patterns-and-principles/#events
-    // see events, by the end of subscription, call `dispose()` to release resource.
     context.subscriptions.push(factory)
   }
 }

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,9 +1,80 @@
 import algosdk from 'algosdk'
 import * as vscode from 'vscode'
 import { CancellationToken, DebugConfiguration, WorkspaceFolder } from 'vscode'
-import { NO_WORKSPACE_ERROR_MESSAGE, SOURCES_FILE_PATTERN } from './constants'
+import { NO_WORKSPACE_ERROR_MESSAGE } from './constants'
 import { workspaceFileAccessor } from './fileAccessor'
 import { bytesToBase64, concatIfTruthy, findFilesInWorkspace, readFileAsJson } from './utils'
+
+type SourcesFile = {
+  'txn-group-sources'?: {
+    'sourcemap-location': string | undefined
+    hash: string
+  }[]
+}
+
+type QuickPickSourceMapItem = {
+  title: string
+  hash: string
+}
+
+const getHashes = (trace: algosdk.modelsv2.SimulationTransactionExecTrace): string[] => {
+  const approvalHash = bytesToBase64(trace.approvalProgramHash)
+  const clearHash = bytesToBase64(trace.clearStateProgramHash)
+  const logicSigHash = bytesToBase64(trace.logicSigHash)
+  const hashes = concatIfTruthy<string>([], [approvalHash, clearHash, logicSigHash])
+
+  if (trace.innerTrace) {
+    return hashes.concat(trace.innerTrace.flatMap((it) => getHashes(it)))
+  }
+
+  return hashes
+}
+
+const getSourceMapQuickPickItems = (hashes: string[], trace: algosdk.modelsv2.SimulateResponse): Record<string, QuickPickSourceMapItem> => {
+  const identifiers: Record<string, QuickPickSourceMapItem> = {}
+
+  trace.txnGroups.forEach((group) => {
+    group.txnResults.forEach((result) => {
+      if (!result.execTrace) return
+
+      hashes.forEach((hash) => {
+        const { execTrace, txnResult } = result
+        if (!execTrace) return
+
+        const { approvalProgramHash, clearStateProgramHash, logicSigHash } = execTrace
+        const { txn, lsig } = txnResult.txn
+
+        if (hash === bytesToBase64(approvalProgramHash) || hash === bytesToBase64(clearStateProgramHash)) {
+          const title = txn.apid
+            ? `Select source maps for Application with ID: ${txn.apid}, hash: ${hash}`
+            : `Select source map for Application with hash: ${hash}`
+          identifiers[hash] = { hash, title }
+        } else if (hash === bytesToBase64(logicSigHash)) {
+          const lsigBytes = lsig?.l
+          const lsigAddr = lsigBytes ? new algosdk.LogicSigAccount(lsigBytes).address() : undefined
+          const title = lsigAddr
+            ? `Select source maps for Logic Sig with address: ${lsigAddr}, hash: ${hash}`
+            : `Select source map for Logic Sig with hash: ${hash}`
+          identifiers[hash] = { hash, title }
+        } else if (!identifiers[hash]) {
+          identifiers[hash] = { hash, title: `Select source map for Application with hash: ${hash}` }
+        }
+      })
+    })
+  })
+
+  return identifiers
+}
+
+const getSourceMapType = (uri: vscode.Uri): string => {
+  if (uri.path.includes('puya.map')) {
+    return 'Puya sourcemap'
+  } else if (uri.path.includes('teal.map')) {
+    return 'TEAL sourcemap'
+  }
+
+  return 'Legacy sourcemap'
+}
 
 export class AvmDebugConfigProvider implements vscode.DebugConfigurationProvider {
   async resolveDebugConfiguration(
@@ -40,20 +111,14 @@ export class AvmDebugConfigProvider implements vscode.DebugConfigurationProvider
     let programSourcesDescriptionFile: string | undefined = config.programSourcesDescriptionFile
 
     if (!programSourcesDescriptionFile) {
-      const workspaceFolder = folder
-      const sourcesUris = await findFilesInWorkspace(workspaceFolder, SOURCES_FILE_PATTERN)
+      const algoKitSourcesDir = vscode.Uri.joinPath(folder.uri, '.algokit', 'sources')
+      const defaultSourcesFile = vscode.Uri.joinPath(algoKitSourcesDir, 'sources.avm.json')
 
-      if (sourcesUris.length === 1) {
-        programSourcesDescriptionFile = sourcesUris[0].fsPath
-      } else {
-        const pickedSource = await vscode.commands.executeCommand<string | undefined>(
-          'extension.avmDebugger.getProgramSourcesDescriptionFile',
-          config,
-        )
-        if (!pickedSource) {
-          return null
-        }
-        programSourcesDescriptionFile = vscode.Uri.joinPath(workspaceFolder.uri, pickedSource).fsPath
+      try {
+        await vscode.workspace.fs.stat(defaultSourcesFile)
+        programSourcesDescriptionFile = defaultSourcesFile.fsPath
+      } catch (error) {
+        // File doesn't exist, we'll create it later if needed
       }
     }
 
@@ -79,7 +144,19 @@ export class AvmDebugConfigProvider implements vscode.DebugConfigurationProvider
       sources = {}
     }
 
-    const sourcesHashes = sources['txn-group-sources']?.map((s) => s.hash) ?? []
+    const sourcesHashes = await Promise.all(
+      (sources['txn-group-sources'] ?? []).map(async (s) => {
+        let fileExists: boolean
+        try {
+          fileExists = (await workspaceFileAccessor.readFile(s['sourcemap-location'])) !== undefined
+        } catch (error) {
+          fileExists = false
+        }
+        const shouldInclude = s['sourcemap-location'] !== null && fileExists
+        return shouldInclude ? s.hash : null
+      }),
+    ).then((hashes) => hashes.filter((hash): hash is string => hash !== null))
+
     const missingHashes = uniqueHashes.reduce((acc, hash) => {
       if (!sourcesHashes.includes(hash)) {
         return acc.concat(hash)
@@ -90,51 +167,102 @@ export class AvmDebugConfigProvider implements vscode.DebugConfigurationProvider
 
     if (missingHashes.length > 0) {
       const sourceMapFiles = await findFilesInWorkspace(folder, ['**/*.tok.map', '**/*.teal.map', '**/*.puya.map'])
+      const identifiers = getSourceMapQuickPickItems(missingHashes, simulateTrace)
+
+      // Group source map files by contract name
+      const groupedSourceMaps = await this.groupSourceMapsByContract(sourceMapFiles)
 
       for (const hash of missingHashes) {
-        const selectedSourceMap = await vscode.window.showQuickPick(
-          sourceMapFiles.map((uri) => ({
-            label: vscode.workspace.asRelativePath(uri),
-            uri,
-          })),
-          {
-            placeHolder: `Select source map for program hash "${hash}"`,
-            title: 'Select Source Map',
-          },
-        )
+        const ignoreOption = {
+          label: 'Ignore sourcemap for this hash',
+          detail: "Won't be asked again. Run '> Clear AVM Registry' command to reset choices.",
+          iconPath: new vscode.ThemeIcon('close'),
+        }
 
-        if (selectedSourceMap) {
+        const quickPickItems = [ignoreOption, ...this.createCategorizedQuickPickItems(groupedSourceMaps)]
+
+        const selectedOption = await vscode.window.showQuickPick(quickPickItems, {
+          placeHolder: 'Pick source map or choose to ignore',
+          title: identifiers[hash].title,
+          matchOnDetail: true,
+        })
+
+        if (selectedOption) {
+          const isIgnoreOption = selectedOption.label.includes('Ignore')
+          if (isIgnoreOption) {
+            vscode.window.showInformationMessage(`Sourcemap for hash ${hash} will be ignored.`)
+          }
+          if (!sources['txn-group-sources']) {
+            sources['txn-group-sources'] = []
+          }
           sources['txn-group-sources']?.push({
-            'sourcemap-location': selectedSourceMap.label,
+            'sourcemap-location': isIgnoreOption ? null : selectedOption.label,
             hash,
           })
         }
       }
 
       // Persist updated sources back to the file
+      if (!programSourcesDescriptionFile) {
+        const algoKitSourcesDir = vscode.Uri.joinPath(folder.uri, '.algokit', 'sources')
+        const newSourcesFile = vscode.Uri.joinPath(algoKitSourcesDir, 'sources.avm.json')
+
+        try {
+          await vscode.workspace.fs.createDirectory(algoKitSourcesDir)
+        } catch (error) {
+          // Directory might already exist, ignore the error
+        }
+
+        programSourcesDescriptionFile = newSourcesFile.fsPath
+      }
+
       await workspaceFileAccessor.writeFile(programSourcesDescriptionFile, new TextEncoder().encode(JSON.stringify(sources, null, 2)))
     }
 
     return { ...config, programSourcesDescriptionFile }
   }
-}
 
-type SourcesFile = {
-  'txn-group-sources'?: {
-    'sourcemap-location': string
-    hash: string
-  }[]
-}
+  private async groupSourceMapsByContract(sourceMapFiles: vscode.Uri[]): Promise<Record<string, vscode.Uri[]>> {
+    const groupedSourceMaps: Record<string, vscode.Uri[]> = { Other: [] }
 
-const getHashes = (trace: algosdk.modelsv2.SimulationTransactionExecTrace): string[] => {
-  const approvalHash = bytesToBase64(trace.approvalProgramHash)
-  const clearHash = bytesToBase64(trace.clearStateProgramHash)
-  const logicSigHash = bytesToBase64(trace.logicSigHash)
-  const hashes = concatIfTruthy<string>([], [approvalHash, clearHash, logicSigHash])
+    for (const uri of sourceMapFiles) {
+      const contractFile = vscode.Uri.file(uri.fsPath.replace(/\.(teal\.tok\.map|teal\.map|puya\.map)$/, '.teal'))
+      const contractFileExists = await workspaceFileAccessor
+        .readFile(contractFile.fsPath)
+        .catch(() => false)
+        .then((file) => file !== undefined)
+      if (contractFileExists) {
+        const baseName = workspaceFileAccessor.basename(contractFile.fsPath).replace(/\.(teal|py)$/, '')
+        if (!groupedSourceMaps[baseName]) {
+          groupedSourceMaps[baseName] = []
+        }
+        groupedSourceMaps[baseName].push(uri)
+      } else {
+        groupedSourceMaps['Other'].push(uri)
+      }
+    }
 
-  if (trace.innerTrace) {
-    return hashes.concat(trace.innerTrace.flatMap((it) => getHashes(it)))
+    return groupedSourceMaps
   }
 
-  return hashes
+  private createCategorizedQuickPickItems(groupedSourceMaps: Record<string, vscode.Uri[]>): vscode.QuickPickItem[] {
+    const items: vscode.QuickPickItem[] = []
+
+    for (const [category, uris] of Object.entries(groupedSourceMaps)) {
+      if (uris.length > 0) {
+        items.push({ kind: vscode.QuickPickItemKind.Separator, label: category })
+        items.push(
+          ...uris.map((uri) => ({
+            label: uri.fsPath,
+            detail: getSourceMapType(uri),
+            description: uri.path.endsWith('.map') ? 'Source map file' : undefined,
+            uri,
+            iconPath: new vscode.ThemeIcon('file-code'),
+          })),
+        )
+      }
+    }
+
+    return items
+  }
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,3 +7,4 @@ export const SOURCES_FILE_PATTERN = `**/${SOURCES_FILE_NAME}`
 export const NO_WORKSPACE_ERROR_MESSAGE = 'Visual Studio Code workspace could not be found.'
 
 export const MAX_FILES_TO_SHOW = 100
+export const DEFAULT_SOURCES_AVM_JSON_FILE = '.algokit/sources/sources.avm.json'

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,9 +2,17 @@ import { orderBy } from 'lodash'
 import * as vscode from 'vscode'
 import { workspaceFileAccessor } from './fileAccessor'
 
-export const findFilesInWorkspace = async (folder: vscode.WorkspaceFolder, filePattern: string) => {
-  const files = await vscode.workspace.findFiles(new vscode.RelativePattern(folder, filePattern), '**/node_modules/**')
-  return orderBy(files, ['fsPath'], ['desc'])
+export const findFilesInWorkspace = async (folder: vscode.WorkspaceFolder, filePattern: string | string[] = []) => {
+  const patterns = Array.isArray(filePattern) ? filePattern : [filePattern]
+
+  const filesPromises = patterns.map((pattern) =>
+    vscode.workspace.findFiles(new vscode.RelativePattern(folder, pattern), '**/node_modules/**'),
+  )
+
+  const filesArrays = await Promise.all(filesPromises)
+  const allFiles = Array.from(new Set(filesArrays.flat()))
+
+  return orderBy(allFiles, ['fsPath'], ['desc'])
 }
 
 export const getFilePathRelativeToClosestWorkspace = (folder: vscode.WorkspaceFolder) => (fileUri: vscode.Uri) => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,172 @@
-import { orderBy } from 'lodash'
+import algosdk from 'algosdk'
+import { orderBy, take } from 'lodash'
 import * as vscode from 'vscode'
+import { MAX_FILES_TO_SHOW, NO_WORKSPACE_ERROR_MESSAGE } from './constants'
 import { workspaceFileAccessor } from './fileAccessor'
+
+export async function getSimulateTrace(filePath: string): Promise<algosdk.modelsv2.SimulateResponse | null> {
+  const traceFileContent = await readFileAsJson<Record<string, unknown>>(filePath)
+  if (!traceFileContent) {
+    vscode.window.showErrorMessage(`Could not open the simulate trace file at path "${filePath}".`)
+    return null
+  }
+  return algosdk.modelsv2.SimulateResponse.from_obj_for_encoding(traceFileContent)
+}
+
+export function getUniqueHashes(simulateTrace: algosdk.modelsv2.SimulateResponse): string[] {
+  const hashes = simulateTrace.txnGroups.flatMap((group) =>
+    group.txnResults.flatMap((result) => (result.execTrace ? getHashes(result.execTrace) : [])),
+  )
+  return [...new Set(hashes)]
+}
+
+export function getHashes(trace: algosdk.modelsv2.SimulationTransactionExecTrace): string[] {
+  const approvalHash = bytesToBase64(trace.approvalProgramHash)
+  const clearHash = bytesToBase64(trace.clearStateProgramHash)
+  const logicSigHash = bytesToBase64(trace.logicSigHash)
+  const hashes = concatIfTruthy<string>([], [approvalHash, clearHash, logicSigHash])
+
+  if (trace.innerTrace) {
+    return hashes.concat(trace.innerTrace.flatMap((it) => getHashes(it)))
+  }
+
+  return hashes
+}
+
+export function getSourceMapQuickPickItems(
+  hashes: string[],
+  trace: algosdk.modelsv2.SimulateResponse,
+): Record<string, QuickPickSourceMapItem> {
+  const identifiers: Record<string, QuickPickSourceMapItem> = {}
+
+  trace.txnGroups.forEach((group) => {
+    group.txnResults.forEach((result) => {
+      if (!result.execTrace) return
+
+      hashes.forEach((hash) => {
+        const { execTrace, txnResult } = result
+        if (!execTrace) return
+
+        const { approvalProgramHash, clearStateProgramHash, logicSigHash } = execTrace
+        const { txn, lsig } = txnResult.txn
+
+        if (hash === bytesToBase64(approvalProgramHash) || hash === bytesToBase64(clearStateProgramHash)) {
+          const title = txn.apid
+            ? `Select source maps for Application with ID: ${txn.apid}, hash: ${hash}`
+            : `Select source map for Application with hash: ${hash}`
+          identifiers[hash] = { hash, title }
+        } else if (hash === bytesToBase64(logicSigHash)) {
+          const lsigBytes = lsig?.l
+          const lsigAddr = lsigBytes ? new algosdk.LogicSigAccount(lsigBytes).address() : undefined
+          const title = lsigAddr
+            ? `Select source maps for Logic Sig with address: ${lsigAddr}, hash: ${hash}`
+            : `Select source map for Logic Sig with hash: ${hash}`
+          identifiers[hash] = { hash, title }
+        } else if (!identifiers[hash]) {
+          identifiers[hash] = { hash, title: `Select source map for Application with hash: ${hash}` }
+        }
+      })
+    })
+  })
+
+  return identifiers
+}
+
+export type QuickPickSourceMapItem = {
+  title: string
+  hash: string
+}
+
+export interface QuickPickWithUri extends vscode.QuickPickItem {
+  uri?: vscode.Uri
+}
+
+export type SourcesFile = {
+  'txn-group-sources'?: {
+    'sourcemap-location': string | null
+    hash: string
+  }[]
+}
+
+export function getMissingHashes(uniqueHashes: string[], sources: SourcesFile): string[] {
+  const sourcesHashes = new Set((sources['txn-group-sources'] ?? []).map((s) => s.hash))
+  return uniqueHashes.filter((hash) => !sourcesHashes.has(hash))
+}
+
+export async function getWorkspaceFolder(resource?: vscode.Uri): Promise<vscode.WorkspaceFolder | undefined> {
+  let workspaceFolder: vscode.WorkspaceFolder | undefined
+
+  if (resource) {
+    workspaceFolder = vscode.workspace.getWorkspaceFolder(resource)
+  } else {
+    workspaceFolder = vscode.workspace.workspaceFolders?.[0]
+  }
+
+  if (!workspaceFolder) {
+    vscode.window.showErrorMessage(NO_WORKSPACE_ERROR_MESSAGE)
+  }
+
+  return workspaceFolder
+}
+
+export async function findAndPickFile(
+  workspaceFolder: vscode.WorkspaceFolder,
+  filePattern: string,
+  options: {
+    title: string
+    placeHolder: string
+    noFilesErrorMessage: string
+    allowBrowse?: boolean
+    fileType?: string
+  },
+): Promise<string | undefined> {
+  const fileUris = await findFilesInWorkspace(workspaceFolder, filePattern)
+
+  const quickPickItems: vscode.QuickPickItem[] = []
+
+  if (fileUris.length === 0) {
+    vscode.window.showWarningMessage(options.noFilesErrorMessage)
+  } else {
+    if (fileUris.length > MAX_FILES_TO_SHOW) {
+      vscode.window.showInformationMessage(`More than ${MAX_FILES_TO_SHOW} files were found in the workspace. Results have been truncated.`)
+    }
+
+    const getRelativeFilePath = getFilePathRelativeToClosestWorkspace(workspaceFolder)
+    const relativeFileUris = take(fileUris, MAX_FILES_TO_SHOW).map(getRelativeFilePath)
+
+    quickPickItems.push(
+      { label: 'Workspace Files', kind: vscode.QuickPickItemKind.Separator },
+      ...relativeFileUris.map((uri) => ({ label: uri })),
+    )
+  }
+
+  if (options.allowBrowse) {
+    quickPickItems.push(
+      { label: 'External Files', kind: vscode.QuickPickItemKind.Separator },
+      { label: 'Browse...', description: `Select external ${options.fileType || 'file'}` },
+    )
+  }
+
+  const selected = await vscode.window.showQuickPick(quickPickItems, {
+    title: options.title,
+    placeHolder: options.placeHolder,
+  })
+
+  if (selected?.label === 'Browse...') {
+    const [file] =
+      (await vscode.window.showOpenDialog({
+        canSelectFiles: true,
+        canSelectFolders: false,
+        canSelectMany: false,
+        filters: options.fileType ? { [options.fileType]: [options.fileType.split('.').pop() || ''] } : undefined,
+        title: `Select ${options.fileType || 'File'}`,
+      })) || []
+
+    return file?.fsPath
+  }
+
+  return selected ? selected.label : undefined
+}
 
 export const findFilesInWorkspace = async (folder: vscode.WorkspaceFolder, filePattern: string | string[] = []) => {
   const patterns = Array.isArray(filePattern) ? filePattern : [filePattern]
@@ -35,6 +201,10 @@ export const readFileAsJson = async <T>(fsPath: string) => {
   } catch (_e) {
     return undefined
   }
+}
+
+export const writeFileAsJson = async <T>(fsPath: string, data: T) => {
+  await workspaceFileAccessor.writeFile(fsPath, new TextEncoder().encode(JSON.stringify(data, null, 2)))
 }
 
 export const bytesToBase64 = (bytes?: Uint8Array) => (bytes ? Buffer.from(bytes).toString('base64') : undefined)


### PR DESCRIPTION
## Proposed Changes

- Refined flow on managing sources.avm.json
- Refined ui pickers (options to ignore sourcemap hash, or pick external file)
- Extension commands to clear/edit sources avm json 
- Extension property to preset default sources.avm.json path 
- Backwards compatibility with previous version of extension 

## Further notes

- Ignore CI issues, wip commits depend on a avm-debugger package, which is currently not available for install from forked repo (hence ref to a manually npm packed file that im using locally). 
- A few more tests cases to be added, but current stack runs correctly (with current local version of avm debugger that does not crash on null 'ignored' sourcemaps + Dan's spike changes)
