### PR TITLE
fix: patching algosdkv3 compatibility issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "algosdk": "^2.9.0",
+        "algosdk": "^3.0.0",
         "avm-debug-adapter": "^0.3.0",
         "lodash": "^4.17.21"
       },
@@ -4145,14 +4145,6 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true
     },
-    "node_modules/algo-msgpack-with-bigint": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/algo-msgpack-with-bigint/-/algo-msgpack-with-bigint-2.1.1.tgz",
-      "integrity": "sha512-F1tGh056XczEaEAqu7s+hlZUDWwOBT70Eq0lfMpBP2YguSQVyxRbprLq5rELXKQOyOaixTWYhMeMQMzP0U5FoQ==",
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/algorand-msgpack": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/algorand-msgpack/-/algorand-msgpack-1.1.0.tgz",
@@ -4163,12 +4155,12 @@
       }
     },
     "node_modules/algosdk": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/algosdk/-/algosdk-2.9.0.tgz",
-      "integrity": "sha512-o0n0nLMbTX6SFQdMUk2/2sy50jmEmZk5OTPYSh2aAeP8DUPxrhjMPfwGsYNvaO+qk75MixC2eWpfA9vygCQ/Mg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/algosdk/-/algosdk-3.0.0.tgz",
+      "integrity": "sha512-PIKZ/YvbBpCudduug4KSH1CY/pTotI7/ccbUIbXKtcI9Onevl+57E+K5X4ow4gsCdysZ8zVvSLdxuCcXvsmPOw==",
+      "license": "MIT",
       "dependencies": {
-        "algo-msgpack-with-bigint": "^2.1.1",
-        "buffer": "^6.0.3",
+        "algorand-msgpack": "^1.1.0",
         "hi-base32": "^0.5.1",
         "js-sha256": "^0.9.0",
         "js-sha3": "^0.8.0",
@@ -4179,29 +4171,6 @@
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "node_modules/algosdk/node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
       }
     },
     "node_modules/ansi-colors": {
@@ -4607,25 +4576,6 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/avm-debug-adapter/node_modules/algosdk": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/algosdk/-/algosdk-3.0.0.tgz",
-      "integrity": "sha512-PIKZ/YvbBpCudduug4KSH1CY/pTotI7/ccbUIbXKtcI9Onevl+57E+K5X4ow4gsCdysZ8zVvSLdxuCcXvsmPOw==",
-      "license": "MIT",
-      "dependencies": {
-        "algorand-msgpack": "^1.1.0",
-        "hi-base32": "^0.5.1",
-        "js-sha256": "^0.9.0",
-        "js-sha3": "^0.8.0",
-        "js-sha512": "^0.8.0",
-        "json-bigint": "^1.0.0",
-        "tweetnacl": "^1.0.3",
-        "vlq": "^2.0.4"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/avvio": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/avvio/-/avvio-8.3.0.tgz",
@@ -4707,6 +4657,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9031,6 +8982,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "package": "vsce package"
   },
   "dependencies": {
-    "algosdk": "^2.9.0",
+    "algosdk": "^3.0.0",
     "avm-debug-adapter": "^0.3.0",
     "lodash": "^4.17.21"
   },

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,11 +5,13 @@ import * as vscode from 'vscode'
 import { MAX_FILES_TO_SHOW, NO_WORKSPACE_ERROR_MESSAGE } from './constants'
 import { workspaceFileAccessor } from './fileAccessor'
 
+// NOTE: Changes to 'address' or 'toUint' fields below must be propagated to other algokit repos using similar parsing logic
+// Such as: https://github.com/algorandfoundation/algokit-subscriber-ts/pull/102#discussion_r1888287708
 // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars
 function parseAlgosdkV2SimulateResponse(obj: any): any {
   if (obj === null || typeof obj !== 'object') return obj
 
-  const addressFields = new Set(['snd', 'close', 'aclose', 'rekey', 'rcv', 'arcv', 'fadd', 'asnd'])
+  const addressFields = new Set(['snd', 'close', 'aclose', 'rekey', 'rcv', 'arcv', 'fadd', 'asnd', 'm', 'r', 'f', 'c'])
   const toUintFields = new Set(['gh', 'apaa'])
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
Fixes - https://github.com/algorandfoundation/algokit-avm-vscode-debugger/issues/52, https://github.com/algorandfoundation/algokit-avm-vscode-debugger/issues/51

# Proposed changes

- Migrating to algosdk v3 
- Reusing simulate response parser from avm-debugger package to handle both v3 and v2 algosdk based simulate response objects

Tested against simulate traces from v6 utils + v2 algosdk and v8 utils + v3 algosdk (as per bug descriptions in issues above)