### PR TITLE
chore: bump adapter package to use forked version

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The AlgoKit AVM VS Code Debugger extension enables line-by-line debugging of Alg
 
 ---
 
-The core functionality is built on top of the [AVM Debug Adapter](https://github.com/algorand/avm-debugger). Additionally, a set of companion utilities are provided in the [TypeScript](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/docs/capabilities/debugging.md) and [Python](https://github.com/algorandfoundation/algokit-utils-py/blob/main/docs/source/capabilities/debugging.md) versions of `algokit-utils`, making it easier for developers to set up the required prerequisites and run the debugger.
+The core functionality is built on top of the [AlgoKit AVM Debug Adapter](https://github.com/algorandfoundation/algokit-avm-debugger). Additionally, a set of companion utilities are provided in the [TypeScript](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/docs/capabilities/debugging.md) and [Python](https://github.com/algorandfoundation/algokit-utils-py/blob/main/docs/source/capabilities/debugging.md) versions of `algokit-utils`, making it easier for developers to set up the required prerequisites and run the debugger.
 
 > To skip straight to the list of features, go to [Features](#features).
 
@@ -54,8 +54,11 @@ Below is a bare-bones example of how to get started with the AVM Debugger extens
 
    ```typescript
    // In your main file (TypeScript)
-   import { config } from 'algokit-utils-ts'
-   config.configure({ debug: true, traceAll: true })
+   import * as algokit from '@algorandfoundation/algokit-utils'
+   import { registerDebugEventHandlers } from '@algorandfoundation/algokit-utils-debug'
+
+   algokit.Config.configure({ debug: true, traceAll: true })
+   registerDebugEventHandlers()
    ```
 
    or
@@ -105,8 +108,11 @@ config.configure(debug=True, trace_all=True)
 
 ```ts
 // Place this code in a project entry point (e.g. index.ts)
-import { config } from 'algokit-utils-ts'
-config.configure({ debug: true, traceAll: true })
+import * as algokit from '@algorandfoundation/algokit-utils'
+import { registerDebugEventHandlers } from '@algorandfoundation/algokit-utils-debug'
+
+algokit.Config.configure({ debug: true, traceAll: true })
+registerDebugEventHandlers()
 ```
 
 > NOTE: Storing debug traces is not possible in browser environments, your contract project needs access to filesystem via `node`. If you wish to extract simulate traces manually from an app running in a browser that uses `algokit-utils-ts`, refer to [algokit-utils-ts docs](https://github.com/algorandfoundation/algokit-utils-ts/blob/main/docs/capabilities/debugging.md#debugging-in-browser-environment).

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@algorandfoundation/algokit-avm-debugger": "^1.0.1-beta.1",
+        "@algorandfoundation/algokit-avm-debugger": "^1.0.1",
         "algosdk": "^3.0.0",
         "lodash": "^4.17.21"
       },
@@ -58,9 +58,9 @@
       }
     },
     "node_modules/@algorandfoundation/algokit-avm-debugger": {
-      "version": "1.0.1-beta.1",
-      "resolved": "https://registry.npmjs.org/@algorandfoundation/algokit-avm-debugger/-/algokit-avm-debugger-1.0.1-beta.1.tgz",
-      "integrity": "sha512-rYKjogI+dfiMKSxJ/qiX6OE9MQMggRbYp2LbSy2umYcXyGjJtIh8z3on+U0GajUYD5cLy3R4MCJxuCbm+3sxBg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@algorandfoundation/algokit-avm-debugger/-/algokit-avm-debugger-1.0.1.tgz",
+      "integrity": "sha512-C/VjoNS9dIDlXaUThV+N5hEW0kLK6ilFbHBPGI6vAsdocgNJ80Llc6Ii3VWSF5nJXjwnyY57yszH+DRALr/BTg==",
       "license": "MIT",
       "dependencies": {
         "@vscode/debugadapter": "^1.64.0",
@@ -3310,20 +3310,20 @@
       }
     },
     "node_modules/@wdio/cli": {
-      "version": "8.40.6",
-      "resolved": "https://registry.npmjs.org/@wdio/cli/-/cli-8.40.6.tgz",
-      "integrity": "sha512-YwfDZ80J6bTyzLo9zrdgLSZXZL5+CDWA44zG1Mu22lvBS+0Ds1PXh7qMR+2JGBucO9HlOY0xd/cp2moAj84w8g==",
+      "version": "8.41.0",
+      "resolved": "https://registry.npmjs.org/@wdio/cli/-/cli-8.41.0.tgz",
+      "integrity": "sha512-+f4McBz6M8/oEJLeoYxHNyfvQ4NTGRACKjtw/FdTJ+GYRu8DkU9sgXOo70NIPCMUajVIOtbDVUbLjJKuxWTEFQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "^22.2.0",
         "@vitest/snapshot": "^2.0.4",
-        "@wdio/config": "8.40.6",
-        "@wdio/globals": "8.40.6",
+        "@wdio/config": "8.41.0",
+        "@wdio/globals": "8.41.0",
         "@wdio/logger": "8.38.0",
         "@wdio/protocols": "8.40.3",
-        "@wdio/types": "8.40.6",
-        "@wdio/utils": "8.40.6",
+        "@wdio/types": "8.41.0",
+        "@wdio/utils": "8.41.0",
         "async-exit-hook": "^2.0.1",
         "chalk": "^5.2.0",
         "chokidar": "^4.0.0",
@@ -3338,7 +3338,7 @@
         "lodash.union": "^4.6.0",
         "read-pkg-up": "10.0.0",
         "recursive-readdir": "^2.2.3",
-        "webdriverio": "8.40.6",
+        "webdriverio": "8.41.0",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -3349,13 +3349,13 @@
       }
     },
     "node_modules/@wdio/cli/node_modules/@types/node": {
-      "version": "22.7.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
-      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+      "version": "22.10.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.5.tgz",
+      "integrity": "sha512-F8Q+SeGimwOo86fiovQh8qiXfFEh2/ocYv7tU5pJ3EXMSSxk1Joj5wefpFK2fHTf/N6HKGSxIDBT9f3gCxXPkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.19.2"
+        "undici-types": "~6.20.0"
       }
     },
     "node_modules/@wdio/cli/node_modules/@wdio/logger": {
@@ -3375,9 +3375,9 @@
       }
     },
     "node_modules/@wdio/cli/node_modules/@wdio/types": {
-      "version": "8.40.6",
-      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-8.40.6.tgz",
-      "integrity": "sha512-ALftLri1BdsRuPrQkuW3evBNdOA5n4IkuoegOw6UE2z+R0f1YI5fHGSHNRWLnhtbOECbGyHXXqzbSxCEb+o+MA==",
+      "version": "8.41.0",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-8.41.0.tgz",
+      "integrity": "sha512-t4NaNTvJZci3Xv/yUZPH4eTL0hxrVTf5wdwNnYIBrzMnlRDbNefjQ0P7FM7ZjQCLaH92AEH6t/XanUId7Webug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3388,19 +3388,19 @@
       }
     },
     "node_modules/@wdio/cli/node_modules/@wdio/utils": {
-      "version": "8.40.6",
-      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-8.40.6.tgz",
-      "integrity": "sha512-+TWfV6h+4f8gs7QiYUAWbWEylpZudQ+xkJPN34tRzPJK6dOBYEnIT/j6+1m3j39m1WPDehyYxIf1wCsrGKBxNQ==",
+      "version": "8.41.0",
+      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-8.41.0.tgz",
+      "integrity": "sha512-0TcTjBiax1VxtJQ/iQA0ZyYOSHjjX2ARVmEI0AMo9+AuIq+xBfnY561+v8k9GqOMPKsiH/HrK3xwjx8xCVS03g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@puppeteer/browsers": "^1.6.0",
         "@wdio/logger": "8.38.0",
-        "@wdio/types": "8.40.6",
+        "@wdio/types": "8.41.0",
         "decamelize": "^6.0.0",
         "deepmerge-ts": "^5.1.0",
         "edgedriver": "^5.5.0",
-        "geckodriver": "^4.3.1",
+        "geckodriver": "~4.2.0",
         "get-port": "^7.0.0",
         "import-meta-resolve": "^4.0.0",
         "locate-app": "^2.1.0",
@@ -3426,9 +3426,9 @@
       }
     },
     "node_modules/@wdio/cli/node_modules/chalk": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
+      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3490,6 +3490,30 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
+    "node_modules/@wdio/cli/node_modules/geckodriver": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/geckodriver/-/geckodriver-4.2.1.tgz",
+      "integrity": "sha512-4m/CRk0OI8MaANRuFIahvOxYTSjlNAO2p9JmE14zxueknq6cdtB5M9UGRQ8R9aMV0bLGNVHHDnDXmoXdOwJfWg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@wdio/logger": "^8.11.0",
+        "decamelize": "^6.0.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.1",
+        "tar-fs": "^3.0.4",
+        "unzipper": "^0.10.14",
+        "which": "^4.0.0"
+      },
+      "bin": {
+        "geckodriver": "bin/geckodriver.js"
+      },
+      "engines": {
+        "node": "^16.13 || >=18 || >=20"
+      }
+    },
     "node_modules/@wdio/cli/node_modules/get-stream": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
@@ -3509,6 +3533,16 @@
       "dev": true,
       "engines": {
         "node": ">=16.17.0"
+      }
+    },
+    "node_modules/@wdio/cli/node_modules/isexe": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
+      "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/@wdio/cli/node_modules/readdirp": {
@@ -3553,23 +3587,66 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/@wdio/cli/node_modules/tar-fs": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.7.tgz",
+      "integrity": "sha512-2sAfoF/zw/2n8goUGnGRZTWTD4INtnScPZvyYBI6BDlJ3wNR5o1dw03EfBvuhG6GBLvC4J+C7j7W+64aZ0ogQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^2.1.1",
+        "bare-path": "^2.1.0"
+      }
+    },
+    "node_modules/@wdio/cli/node_modules/tar-stream": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
     "node_modules/@wdio/cli/node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@wdio/cli/node_modules/which": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
+      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^3.1.1"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/@wdio/config": {
-      "version": "8.40.6",
-      "resolved": "https://registry.npmjs.org/@wdio/config/-/config-8.40.6.tgz",
-      "integrity": "sha512-rHCSmrhdJf7FlidcQPDvRKRPLYjklbrdxQa6J20BxHifTO4h2v23Wrq4OqqYIcq23gf9LpZvCA/PAMiET/QdVg==",
+      "version": "8.41.0",
+      "resolved": "https://registry.npmjs.org/@wdio/config/-/config-8.41.0.tgz",
+      "integrity": "sha512-/6Z3sfSyhX5oVde0l01fyHimbqRYIVUDBnhDG2EMSCoC2lsaJX3Bm3IYpYHYHHFsgoDCi3B3Gv++t9dn2eSZZw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@wdio/logger": "8.38.0",
-        "@wdio/types": "8.40.6",
-        "@wdio/utils": "8.40.6",
+        "@wdio/types": "8.41.0",
+        "@wdio/utils": "8.41.0",
         "decamelize": "^6.0.0",
         "deepmerge-ts": "^5.0.0",
         "glob": "^10.2.2",
@@ -3580,13 +3657,13 @@
       }
     },
     "node_modules/@wdio/config/node_modules/@types/node": {
-      "version": "22.7.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
-      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+      "version": "22.10.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.5.tgz",
+      "integrity": "sha512-F8Q+SeGimwOo86fiovQh8qiXfFEh2/ocYv7tU5pJ3EXMSSxk1Joj5wefpFK2fHTf/N6HKGSxIDBT9f3gCxXPkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.19.2"
+        "undici-types": "~6.20.0"
       }
     },
     "node_modules/@wdio/config/node_modules/@wdio/logger": {
@@ -3606,9 +3683,9 @@
       }
     },
     "node_modules/@wdio/config/node_modules/@wdio/types": {
-      "version": "8.40.6",
-      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-8.40.6.tgz",
-      "integrity": "sha512-ALftLri1BdsRuPrQkuW3evBNdOA5n4IkuoegOw6UE2z+R0f1YI5fHGSHNRWLnhtbOECbGyHXXqzbSxCEb+o+MA==",
+      "version": "8.41.0",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-8.41.0.tgz",
+      "integrity": "sha512-t4NaNTvJZci3Xv/yUZPH4eTL0hxrVTf5wdwNnYIBrzMnlRDbNefjQ0P7FM7ZjQCLaH92AEH6t/XanUId7Webug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3619,19 +3696,19 @@
       }
     },
     "node_modules/@wdio/config/node_modules/@wdio/utils": {
-      "version": "8.40.6",
-      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-8.40.6.tgz",
-      "integrity": "sha512-+TWfV6h+4f8gs7QiYUAWbWEylpZudQ+xkJPN34tRzPJK6dOBYEnIT/j6+1m3j39m1WPDehyYxIf1wCsrGKBxNQ==",
+      "version": "8.41.0",
+      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-8.41.0.tgz",
+      "integrity": "sha512-0TcTjBiax1VxtJQ/iQA0ZyYOSHjjX2ARVmEI0AMo9+AuIq+xBfnY561+v8k9GqOMPKsiH/HrK3xwjx8xCVS03g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@puppeteer/browsers": "^1.6.0",
         "@wdio/logger": "8.38.0",
-        "@wdio/types": "8.40.6",
+        "@wdio/types": "8.41.0",
         "decamelize": "^6.0.0",
         "deepmerge-ts": "^5.1.0",
         "edgedriver": "^5.5.0",
-        "geckodriver": "^4.3.1",
+        "geckodriver": "~4.2.0",
         "get-port": "^7.0.0",
         "import-meta-resolve": "^4.0.0",
         "locate-app": "^2.1.0",
@@ -3657,9 +3734,9 @@
       }
     },
     "node_modules/@wdio/config/node_modules/chalk": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
+      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3682,6 +3759,40 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@wdio/config/node_modules/geckodriver": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/geckodriver/-/geckodriver-4.2.1.tgz",
+      "integrity": "sha512-4m/CRk0OI8MaANRuFIahvOxYTSjlNAO2p9JmE14zxueknq6cdtB5M9UGRQ8R9aMV0bLGNVHHDnDXmoXdOwJfWg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@wdio/logger": "^8.11.0",
+        "decamelize": "^6.0.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.1",
+        "tar-fs": "^3.0.4",
+        "unzipper": "^0.10.14",
+        "which": "^4.0.0"
+      },
+      "bin": {
+        "geckodriver": "bin/geckodriver.js"
+      },
+      "engines": {
+        "node": "^16.13 || >=18 || >=20"
+      }
+    },
+    "node_modules/@wdio/config/node_modules/isexe": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
+      "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/@wdio/config/node_modules/strip-ansi": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
@@ -3698,17 +3809,60 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/@wdio/config/node_modules/tar-fs": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.7.tgz",
+      "integrity": "sha512-2sAfoF/zw/2n8goUGnGRZTWTD4INtnScPZvyYBI6BDlJ3wNR5o1dw03EfBvuhG6GBLvC4J+C7j7W+64aZ0ogQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^2.1.1",
+        "bare-path": "^2.1.0"
+      }
+    },
+    "node_modules/@wdio/config/node_modules/tar-stream": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
     "node_modules/@wdio/config/node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@wdio/config/node_modules/which": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
+      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^3.1.1"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/@wdio/globals": {
-      "version": "8.40.6",
-      "resolved": "https://registry.npmjs.org/@wdio/globals/-/globals-8.40.6.tgz",
-      "integrity": "sha512-37llSQk4ngM6wzn8diBQ1Xik2ZZtUCU29Hr7NbfyfXahQdzIApRxNtw0B2J5XrjGX9yuO6gdyg5Kj+UuaKIo7A==",
+      "version": "8.41.0",
+      "resolved": "https://registry.npmjs.org/@wdio/globals/-/globals-8.41.0.tgz",
+      "integrity": "sha512-xfUpEppdKzMHy4qoSoQN1cXoBPPh7oMeX+U/jtdvOtla+dd/YZ8pu47zLhQ/GM3gDVrBGnO4w3u4L6Zf/P3KEw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3716,21 +3870,21 @@
       },
       "optionalDependencies": {
         "expect-webdriverio": "^4.11.2",
-        "webdriverio": "8.40.6"
+        "webdriverio": "8.41.0"
       }
     },
     "node_modules/@wdio/local-runner": {
-      "version": "8.40.6",
-      "resolved": "https://registry.npmjs.org/@wdio/local-runner/-/local-runner-8.40.6.tgz",
-      "integrity": "sha512-h2OvQ6kODNiEaM6JzYzTzPl4n9TiqM2KsQ+8x3QoMIHY7Z9JSc+cH9QcnNsm3Sqxk/LVYFGetza6/WTsHx1/zA==",
+      "version": "8.41.0",
+      "resolved": "https://registry.npmjs.org/@wdio/local-runner/-/local-runner-8.41.0.tgz",
+      "integrity": "sha512-A5msAjAC8gqiWvtFl+VNm9BBlVb5q3a2o7i+L+Cw7idV3aFY5etigB2wLYMtyBWgB8cXvbZaxXizHhGvZ+iB8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "^22.2.0",
         "@wdio/logger": "8.38.0",
         "@wdio/repl": "8.40.3",
-        "@wdio/runner": "8.40.6",
-        "@wdio/types": "8.40.6",
+        "@wdio/runner": "8.41.0",
+        "@wdio/types": "8.41.0",
         "async-exit-hook": "^2.0.1",
         "split2": "^4.1.0",
         "stream-buffers": "^3.0.2"
@@ -3740,13 +3894,13 @@
       }
     },
     "node_modules/@wdio/local-runner/node_modules/@types/node": {
-      "version": "22.7.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
-      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+      "version": "22.10.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.5.tgz",
+      "integrity": "sha512-F8Q+SeGimwOo86fiovQh8qiXfFEh2/ocYv7tU5pJ3EXMSSxk1Joj5wefpFK2fHTf/N6HKGSxIDBT9f3gCxXPkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.19.2"
+        "undici-types": "~6.20.0"
       }
     },
     "node_modules/@wdio/local-runner/node_modules/@wdio/logger": {
@@ -3766,9 +3920,9 @@
       }
     },
     "node_modules/@wdio/local-runner/node_modules/@wdio/types": {
-      "version": "8.40.6",
-      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-8.40.6.tgz",
-      "integrity": "sha512-ALftLri1BdsRuPrQkuW3evBNdOA5n4IkuoegOw6UE2z+R0f1YI5fHGSHNRWLnhtbOECbGyHXXqzbSxCEb+o+MA==",
+      "version": "8.41.0",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-8.41.0.tgz",
+      "integrity": "sha512-t4NaNTvJZci3Xv/yUZPH4eTL0hxrVTf5wdwNnYIBrzMnlRDbNefjQ0P7FM7ZjQCLaH92AEH6t/XanUId7Webug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3821,9 +3975,9 @@
       }
     },
     "node_modules/@wdio/local-runner/node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
       "dev": true,
       "license": "MIT"
     },
@@ -3970,36 +4124,36 @@
       }
     },
     "node_modules/@wdio/runner": {
-      "version": "8.40.6",
-      "resolved": "https://registry.npmjs.org/@wdio/runner/-/runner-8.40.6.tgz",
-      "integrity": "sha512-dScN5mLia3YYctEgrbO4JG7pEttICfNENFd08t1T/hNJAWyzSbG/wvAL5k0HUGqp6Ukly6NUmhVsP5PVBz4ooA==",
+      "version": "8.41.0",
+      "resolved": "https://registry.npmjs.org/@wdio/runner/-/runner-8.41.0.tgz",
+      "integrity": "sha512-eQ9vZaHIXBLw7XqiKsasiUGjC8PgJawnHFMPKS0i/4ds+5arHo6ciX0s2uhJ3j/EHw3PYvFPCREp/sXetRuNlQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "^22.2.0",
-        "@wdio/config": "8.40.6",
-        "@wdio/globals": "8.40.6",
+        "@wdio/config": "8.41.0",
+        "@wdio/globals": "8.41.0",
         "@wdio/logger": "8.38.0",
-        "@wdio/types": "8.40.6",
-        "@wdio/utils": "8.40.6",
+        "@wdio/types": "8.41.0",
+        "@wdio/utils": "8.41.0",
         "deepmerge-ts": "^5.1.0",
         "expect-webdriverio": "^4.12.0",
         "gaze": "^1.1.3",
-        "webdriver": "8.40.6",
-        "webdriverio": "8.40.6"
+        "webdriver": "8.41.0",
+        "webdriverio": "8.41.0"
       },
       "engines": {
         "node": "^16.13 || >=18"
       }
     },
     "node_modules/@wdio/runner/node_modules/@types/node": {
-      "version": "22.7.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
-      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+      "version": "22.10.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.5.tgz",
+      "integrity": "sha512-F8Q+SeGimwOo86fiovQh8qiXfFEh2/ocYv7tU5pJ3EXMSSxk1Joj5wefpFK2fHTf/N6HKGSxIDBT9f3gCxXPkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.19.2"
+        "undici-types": "~6.20.0"
       }
     },
     "node_modules/@wdio/runner/node_modules/@wdio/logger": {
@@ -4019,9 +4173,9 @@
       }
     },
     "node_modules/@wdio/runner/node_modules/@wdio/types": {
-      "version": "8.40.6",
-      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-8.40.6.tgz",
-      "integrity": "sha512-ALftLri1BdsRuPrQkuW3evBNdOA5n4IkuoegOw6UE2z+R0f1YI5fHGSHNRWLnhtbOECbGyHXXqzbSxCEb+o+MA==",
+      "version": "8.41.0",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-8.41.0.tgz",
+      "integrity": "sha512-t4NaNTvJZci3Xv/yUZPH4eTL0hxrVTf5wdwNnYIBrzMnlRDbNefjQ0P7FM7ZjQCLaH92AEH6t/XanUId7Webug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4032,19 +4186,19 @@
       }
     },
     "node_modules/@wdio/runner/node_modules/@wdio/utils": {
-      "version": "8.40.6",
-      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-8.40.6.tgz",
-      "integrity": "sha512-+TWfV6h+4f8gs7QiYUAWbWEylpZudQ+xkJPN34tRzPJK6dOBYEnIT/j6+1m3j39m1WPDehyYxIf1wCsrGKBxNQ==",
+      "version": "8.41.0",
+      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-8.41.0.tgz",
+      "integrity": "sha512-0TcTjBiax1VxtJQ/iQA0ZyYOSHjjX2ARVmEI0AMo9+AuIq+xBfnY561+v8k9GqOMPKsiH/HrK3xwjx8xCVS03g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@puppeteer/browsers": "^1.6.0",
         "@wdio/logger": "8.38.0",
-        "@wdio/types": "8.40.6",
+        "@wdio/types": "8.41.0",
         "decamelize": "^6.0.0",
         "deepmerge-ts": "^5.1.0",
         "edgedriver": "^5.5.0",
-        "geckodriver": "^4.3.1",
+        "geckodriver": "~4.2.0",
         "get-port": "^7.0.0",
         "import-meta-resolve": "^4.0.0",
         "locate-app": "^2.1.0",
@@ -4070,9 +4224,9 @@
       }
     },
     "node_modules/@wdio/runner/node_modules/chalk": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
+      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4095,6 +4249,40 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@wdio/runner/node_modules/geckodriver": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/geckodriver/-/geckodriver-4.2.1.tgz",
+      "integrity": "sha512-4m/CRk0OI8MaANRuFIahvOxYTSjlNAO2p9JmE14zxueknq6cdtB5M9UGRQ8R9aMV0bLGNVHHDnDXmoXdOwJfWg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@wdio/logger": "^8.11.0",
+        "decamelize": "^6.0.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.1",
+        "tar-fs": "^3.0.4",
+        "unzipper": "^0.10.14",
+        "which": "^4.0.0"
+      },
+      "bin": {
+        "geckodriver": "bin/geckodriver.js"
+      },
+      "engines": {
+        "node": "^16.13 || >=18 || >=20"
+      }
+    },
+    "node_modules/@wdio/runner/node_modules/isexe": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
+      "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/@wdio/runner/node_modules/strip-ansi": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
@@ -4111,12 +4299,55 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/@wdio/runner/node_modules/tar-fs": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.7.tgz",
+      "integrity": "sha512-2sAfoF/zw/2n8goUGnGRZTWTD4INtnScPZvyYBI6BDlJ3wNR5o1dw03EfBvuhG6GBLvC4J+C7j7W+64aZ0ogQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^2.1.1",
+        "bare-path": "^2.1.0"
+      }
+    },
+    "node_modules/@wdio/runner/node_modules/tar-stream": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
     "node_modules/@wdio/runner/node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@wdio/runner/node_modules/which": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
+      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^3.1.1"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^16.13.0 || >=18.0.0"
+      }
     },
     "node_modules/@wdio/spec-reporter": {
       "version": "8.32.4",
@@ -6240,10 +6471,11 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -11831,10 +12063,11 @@
       "dev": true
     },
     "node_modules/npm-run-all/node_modules/cross-spawn": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.6.tgz",
+      "integrity": "sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "nice-try": "^1.0.4",
         "path-key": "^2.0.1",
@@ -19197,19 +19430,19 @@
       }
     },
     "node_modules/webdriver": {
-      "version": "8.40.6",
-      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-8.40.6.tgz",
-      "integrity": "sha512-jkslwUvOmqhFfc1E21Tz48NgYD8ykiR+09iWZlVLtx3P43k4jOfS+CfasvQ+6hJiVck+N5dXjYfg6zDjpkIFRw==",
+      "version": "8.41.0",
+      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-8.41.0.tgz",
+      "integrity": "sha512-n8OrFnVT4hAaGa0Advr3T8ObJdeKNTRklHIEzM2CYVx/5DZt+2KwaKSxWsURNd4zU7FbsfaJUU4rQWCmvozQLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "^22.2.0",
         "@types/ws": "^8.5.3",
-        "@wdio/config": "8.40.6",
+        "@wdio/config": "8.41.0",
         "@wdio/logger": "8.38.0",
         "@wdio/protocols": "8.40.3",
-        "@wdio/types": "8.40.6",
-        "@wdio/utils": "8.40.6",
+        "@wdio/types": "8.41.0",
+        "@wdio/utils": "8.41.0",
         "deepmerge-ts": "^5.1.0",
         "got": "^12.6.1",
         "ky": "^0.33.0",
@@ -19220,13 +19453,13 @@
       }
     },
     "node_modules/webdriver/node_modules/@types/node": {
-      "version": "22.7.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
-      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+      "version": "22.10.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.5.tgz",
+      "integrity": "sha512-F8Q+SeGimwOo86fiovQh8qiXfFEh2/ocYv7tU5pJ3EXMSSxk1Joj5wefpFK2fHTf/N6HKGSxIDBT9f3gCxXPkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.19.2"
+        "undici-types": "~6.20.0"
       }
     },
     "node_modules/webdriver/node_modules/@wdio/logger": {
@@ -19246,9 +19479,9 @@
       }
     },
     "node_modules/webdriver/node_modules/@wdio/types": {
-      "version": "8.40.6",
-      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-8.40.6.tgz",
-      "integrity": "sha512-ALftLri1BdsRuPrQkuW3evBNdOA5n4IkuoegOw6UE2z+R0f1YI5fHGSHNRWLnhtbOECbGyHXXqzbSxCEb+o+MA==",
+      "version": "8.41.0",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-8.41.0.tgz",
+      "integrity": "sha512-t4NaNTvJZci3Xv/yUZPH4eTL0hxrVTf5wdwNnYIBrzMnlRDbNefjQ0P7FM7ZjQCLaH92AEH6t/XanUId7Webug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -19259,19 +19492,19 @@
       }
     },
     "node_modules/webdriver/node_modules/@wdio/utils": {
-      "version": "8.40.6",
-      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-8.40.6.tgz",
-      "integrity": "sha512-+TWfV6h+4f8gs7QiYUAWbWEylpZudQ+xkJPN34tRzPJK6dOBYEnIT/j6+1m3j39m1WPDehyYxIf1wCsrGKBxNQ==",
+      "version": "8.41.0",
+      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-8.41.0.tgz",
+      "integrity": "sha512-0TcTjBiax1VxtJQ/iQA0ZyYOSHjjX2ARVmEI0AMo9+AuIq+xBfnY561+v8k9GqOMPKsiH/HrK3xwjx8xCVS03g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@puppeteer/browsers": "^1.6.0",
         "@wdio/logger": "8.38.0",
-        "@wdio/types": "8.40.6",
+        "@wdio/types": "8.41.0",
         "decamelize": "^6.0.0",
         "deepmerge-ts": "^5.1.0",
         "edgedriver": "^5.5.0",
-        "geckodriver": "^4.3.1",
+        "geckodriver": "~4.2.0",
         "get-port": "^7.0.0",
         "import-meta-resolve": "^4.0.0",
         "locate-app": "^2.1.0",
@@ -19297,9 +19530,9 @@
       }
     },
     "node_modules/webdriver/node_modules/chalk": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
+      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -19320,6 +19553,30 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/webdriver/node_modules/geckodriver": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/geckodriver/-/geckodriver-4.2.1.tgz",
+      "integrity": "sha512-4m/CRk0OI8MaANRuFIahvOxYTSjlNAO2p9JmE14zxueknq6cdtB5M9UGRQ8R9aMV0bLGNVHHDnDXmoXdOwJfWg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@wdio/logger": "^8.11.0",
+        "decamelize": "^6.0.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.1",
+        "tar-fs": "^3.0.4",
+        "unzipper": "^0.10.14",
+        "which": "^4.0.0"
+      },
+      "bin": {
+        "geckodriver": "bin/geckodriver.js"
+      },
+      "engines": {
+        "node": "^16.13 || >=18 || >=20"
       }
     },
     "node_modules/webdriver/node_modules/got": {
@@ -19348,6 +19605,16 @@
         "url": "https://github.com/sindresorhus/got?sponsor=1"
       }
     },
+    "node_modules/webdriver/node_modules/isexe": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
+      "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/webdriver/node_modules/strip-ansi": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
@@ -19364,27 +19631,70 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/webdriver/node_modules/tar-fs": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.7.tgz",
+      "integrity": "sha512-2sAfoF/zw/2n8goUGnGRZTWTD4INtnScPZvyYBI6BDlJ3wNR5o1dw03EfBvuhG6GBLvC4J+C7j7W+64aZ0ogQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^2.1.1",
+        "bare-path": "^2.1.0"
+      }
+    },
+    "node_modules/webdriver/node_modules/tar-stream": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
     "node_modules/webdriver/node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/webdriver/node_modules/which": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
+      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^3.1.1"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/webdriverio": {
-      "version": "8.40.6",
-      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-8.40.6.tgz",
-      "integrity": "sha512-hMFYRjVU5Nnk2e9Mi8kDx/IVFMWGaVyDCDpv/SeXXCP17DT9jAZtOWlwGhRaLVikN5JYYuHavHyatVa7gj6QTg==",
+      "version": "8.41.0",
+      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-8.41.0.tgz",
+      "integrity": "sha512-WlQfw0mUEhTS8DPr+TBSYMhEnqXkFr2dcUwPb5XkffTB+i0wftf+BLXJPSVD9M1PTLyYcFdCIu68pqR54dq5BA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "^22.2.0",
-        "@wdio/config": "8.40.6",
+        "@wdio/config": "8.41.0",
         "@wdio/logger": "8.38.0",
         "@wdio/protocols": "8.40.3",
         "@wdio/repl": "8.40.3",
-        "@wdio/types": "8.40.6",
-        "@wdio/utils": "8.40.6",
+        "@wdio/types": "8.41.0",
+        "@wdio/utils": "8.41.0",
         "archiver": "^7.0.0",
         "aria-query": "^5.0.0",
         "css-shorthand-properties": "^1.1.1",
@@ -19402,7 +19712,7 @@
         "resq": "^1.9.1",
         "rgb2hex": "0.2.5",
         "serialize-error": "^11.0.1",
-        "webdriver": "8.40.6"
+        "webdriver": "8.41.0"
       },
       "engines": {
         "node": "^16.13 || >=18"
@@ -19417,13 +19727,13 @@
       }
     },
     "node_modules/webdriverio/node_modules/@types/node": {
-      "version": "22.7.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
-      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+      "version": "22.10.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.5.tgz",
+      "integrity": "sha512-F8Q+SeGimwOo86fiovQh8qiXfFEh2/ocYv7tU5pJ3EXMSSxk1Joj5wefpFK2fHTf/N6HKGSxIDBT9f3gCxXPkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.19.2"
+        "undici-types": "~6.20.0"
       }
     },
     "node_modules/webdriverio/node_modules/@wdio/logger": {
@@ -19443,9 +19753,9 @@
       }
     },
     "node_modules/webdriverio/node_modules/@wdio/types": {
-      "version": "8.40.6",
-      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-8.40.6.tgz",
-      "integrity": "sha512-ALftLri1BdsRuPrQkuW3evBNdOA5n4IkuoegOw6UE2z+R0f1YI5fHGSHNRWLnhtbOECbGyHXXqzbSxCEb+o+MA==",
+      "version": "8.41.0",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-8.41.0.tgz",
+      "integrity": "sha512-t4NaNTvJZci3Xv/yUZPH4eTL0hxrVTf5wdwNnYIBrzMnlRDbNefjQ0P7FM7ZjQCLaH92AEH6t/XanUId7Webug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -19456,19 +19766,19 @@
       }
     },
     "node_modules/webdriverio/node_modules/@wdio/utils": {
-      "version": "8.40.6",
-      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-8.40.6.tgz",
-      "integrity": "sha512-+TWfV6h+4f8gs7QiYUAWbWEylpZudQ+xkJPN34tRzPJK6dOBYEnIT/j6+1m3j39m1WPDehyYxIf1wCsrGKBxNQ==",
+      "version": "8.41.0",
+      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-8.41.0.tgz",
+      "integrity": "sha512-0TcTjBiax1VxtJQ/iQA0ZyYOSHjjX2ARVmEI0AMo9+AuIq+xBfnY561+v8k9GqOMPKsiH/HrK3xwjx8xCVS03g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@puppeteer/browsers": "^1.6.0",
         "@wdio/logger": "8.38.0",
-        "@wdio/types": "8.40.6",
+        "@wdio/types": "8.41.0",
         "decamelize": "^6.0.0",
         "deepmerge-ts": "^5.1.0",
         "edgedriver": "^5.5.0",
-        "geckodriver": "^4.3.1",
+        "geckodriver": "~4.2.0",
         "get-port": "^7.0.0",
         "import-meta-resolve": "^4.0.0",
         "locate-app": "^2.1.0",
@@ -19503,9 +19813,9 @@
       }
     },
     "node_modules/webdriverio/node_modules/chalk": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
+      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -19528,6 +19838,30 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/webdriverio/node_modules/geckodriver": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/geckodriver/-/geckodriver-4.2.1.tgz",
+      "integrity": "sha512-4m/CRk0OI8MaANRuFIahvOxYTSjlNAO2p9JmE14zxueknq6cdtB5M9UGRQ8R9aMV0bLGNVHHDnDXmoXdOwJfWg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@wdio/logger": "^8.11.0",
+        "decamelize": "^6.0.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.1",
+        "tar-fs": "^3.0.4",
+        "unzipper": "^0.10.14",
+        "which": "^4.0.0"
+      },
+      "bin": {
+        "geckodriver": "bin/geckodriver.js"
+      },
+      "engines": {
+        "node": "^16.13 || >=18 || >=20"
+      }
+    },
     "node_modules/webdriverio/node_modules/is-plain-obj": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
@@ -19538,6 +19872,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/webdriverio/node_modules/isexe": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
+      "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/webdriverio/node_modules/minimatch": {
@@ -19571,12 +19915,55 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/webdriverio/node_modules/tar-fs": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.7.tgz",
+      "integrity": "sha512-2sAfoF/zw/2n8goUGnGRZTWTD4INtnScPZvyYBI6BDlJ3wNR5o1dw03EfBvuhG6GBLvC4J+C7j7W+64aZ0ogQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^2.1.1",
+        "bare-path": "^2.1.0"
+      }
+    },
+    "node_modules/webdriverio/node_modules/tar-stream": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
     "node_modules/webdriverio/node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/webdriverio/node_modules/which": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
+      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^3.1.1"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^16.13.0 || >=18.0.0"
+      }
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "@algorandfoundation/algokit-avm-debugger": "^1.0.1-beta.1",
         "algosdk": "^3.0.0",
-        "avm-debug-adapter": "^0.3.0",
         "lodash": "^4.17.21"
       },
       "devDependencies": {
@@ -55,6 +55,23 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@algorandfoundation/algokit-avm-debugger": {
+      "version": "1.0.1-beta.1",
+      "resolved": "https://registry.npmjs.org/@algorandfoundation/algokit-avm-debugger/-/algokit-avm-debugger-1.0.1-beta.1.tgz",
+      "integrity": "sha512-rYKjogI+dfiMKSxJ/qiX6OE9MQMggRbYp2LbSy2umYcXyGjJtIh8z3on+U0GajUYD5cLy3R4MCJxuCbm+3sxBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@vscode/debugadapter": "^1.64.0",
+        "algosdk": "^3.0.0",
+        "await-notify": "^1.0.1"
+      },
+      "bin": {
+        "algokit-avm-debugger": "dist/src/cli.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -4956,23 +4973,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/avm-debug-adapter": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/avm-debug-adapter/-/avm-debug-adapter-0.3.0.tgz",
-      "integrity": "sha512-mI9+PkSBTIbeF6EM9trBsdcMvs7t3mosqEglIggAuaD6lbTB/Xd1moQObzGcgkvGud+Khh+zb+oM385yK3l18A==",
-      "license": "MIT",
-      "dependencies": {
-        "@vscode/debugadapter": "^1.64.0",
-        "algosdk": "^3.0.0",
-        "await-notify": "^1.0.1"
-      },
-      "bin": {
-        "avm-debug-adapter": "out/src/cli.js"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/avvio": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "algosdk": "^3.0.0",
-    "@algorandfoundation/algokit-avm-debugger": "^1.0.1-beta.1",
+    "@algorandfoundation/algokit-avm-debugger": "^1.0.1",
     "lodash": "^4.17.21"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "algosdk": "^3.0.0",
-    "avm-debug-adapter": "^0.3.0",
+    "@algorandfoundation/algokit-avm-debugger": "^1.0.1-beta.1",
     "lodash": "^4.17.21"
   },
   "devDependencies": {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,5 +1,5 @@
+import { ProgramSourceEntry, ProgramSourceEntryFile } from '@algorandfoundation/algokit-avm-debugger'
 import algosdk from 'algosdk'
-import { ProgramSourceEntry, ProgramSourceEntryFile } from 'avm-debug-adapter'
 import path from 'path'
 import * as vscode from 'vscode'
 import { CancellationToken, DebugConfiguration, WorkspaceFolder } from 'vscode'

--- a/src/fileAccessor.ts
+++ b/src/fileAccessor.ts
@@ -1,4 +1,4 @@
-import { FileAccessor } from 'avm-debug-adapter'
+import { FileAccessor } from '@algorandfoundation/algokit-avm-debugger'
 import * as vscode from 'vscode'
 
 export const workspaceFileAccessor: FileAccessor = {

--- a/src/inlineDebugAdapterFactory.ts
+++ b/src/inlineDebugAdapterFactory.ts
@@ -1,4 +1,4 @@
-import { AvmDebugSession } from 'avm-debug-adapter'
+import { AvmDebugSession } from '@algorandfoundation/algokit-avm-debugger'
 import * as vscode from 'vscode'
 import { ProviderResult } from 'vscode'
 import { workspaceFileAccessor } from './fileAccessor'

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
+import { ProgramSourceEntryFile } from '@algorandfoundation/algokit-avm-debugger'
 import algosdk from 'algosdk'
-import { ProgramSourceEntryFile } from 'avm-debug-adapter'
 import { orderBy, take } from 'lodash'
 import * as vscode from 'vscode'
 import { MAX_FILES_TO_SHOW, NO_WORKSPACE_ERROR_MESSAGE } from './constants'


### PR DESCRIPTION
Fixes https://github.com/algorandfoundation/algokit-avm-vscode-debugger/issues/57 and https://github.com/algorandfoundation/algokit-avm-vscode-debugger/issues/58

# Proposed changes

- Bumps package version to use debug adapter from foundation's fork
- Fixed minor typos in instructions in main readme