### PR TITLE
fix: windows absolute path resolution

### DIFF
--- a/src/fileAccessor.ts
+++ b/src/fileAccessor.ts
@@ -22,7 +22,7 @@ export const workspaceFileAccessor: FileAccessor = {
   filePathRelativeTo(base: string, filePath: string): string {
     // Check if filePath is an absolute path
     if (this.isWindows) {
-      if (filePath.match(/^[a-zA-Z]:\\/)) {
+      if (filePath.match(/^[a-zA-Z]:[\\/]/)) {
         return filePath
       }
     } else {


### PR DESCRIPTION
# Proposed changes

- Fixes an edge case reported by Rob, additional path handling on windows for puya-ts sourcemaps 