### PR TITLE
chore: updated cd node version to 20.x

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -33,10 +33,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Use Node.js 18.x
+      - name: Use Node.js 20.x
         uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: 20.x
 
       - name: Install dependencies to get semantic release components and plugins
         run: npm ci --ignore-scripts


### PR DESCRIPTION
Updated to the cd workflow to use node 20 because the semantic version nump requires that as the base version 