### PR TITLE
fix: broken ci pipeline due to matching packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
       interval: 'weekly'
     commit-message:
       prefix: 'chore(deps)'
+    ignore:
+      - dependency-name: '@types/vscode'
     groups:
       all:
         patterns:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,23 +47,23 @@ The minimum required VS Code version is specified in the `package.json` file
   },
 ```
 
-- The type definition for VS Code
+- The type definitions for VS Code
 
 ```json
   ...
   "devDependencies": {
     ...
-    "@types/vscode": "1.92.0",
+    "@types/vscode": "~1.92.0",
     ...
   }
 ```
 
-These two component should match to ensure that the extension can be packaged correctly. Note: `@types/vscode` is defined with exact version.
+Note: the dependency `@types/vscode` only accept patch updates because VS Code type definitions can be different between minor updates.
 
-To update it, run:
+To update the minimum required VS Code version, run:
 
 ```bash
-npm install @types/vscode@{new-version} --save-dev --save-exact
+npm install @types/vscode@1.92.0 --save-dev --save-prefix='~'
 ```
 
-where `{new-version}` is the new version. This updates the VS Code engine as well as `@types/vscode` package.
+where `{new-version}` is the new version. This command will update both elements.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,3 +34,36 @@
 ## Commits
 
 We are using the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard for commit messages. This allows us to automatically generate release notes and version numbers. We do this via [Semantic Release](https://semantic-release.gitbook.io/semantic-release/) and [GitHub actions](.github/workflows/cd.yaml).
+
+## Update minimum required VS Code version
+
+The minimum required VS Code version is specified in the `package.json` file
+
+- The required VS Code version
+
+```json
+  "engines": {
+    "vscode": "^1.92.0"
+  },
+```
+
+- The type definition for VS Code
+
+```json
+  ...
+  "devDependencies": {
+    ...
+    "@types/vscode": "1.92.0",
+    ...
+  }
+```
+
+These two component should match to ensure that the extension can be packaged correctly. Note: `@types/vscode` is defined with exact version.
+
+To update it, run:
+
+```bash
+npm install @types/vscode@{new-version} --save-dev --save-exact
+```
+
+where `{new-version}` is the new version. This updates the VS Code engine as well as `@types/vscode` package.

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@types/lodash": "^4.17.7",
         "@types/mocha": "^10.0.7",
         "@types/node": "^18.18.11",
-        "@types/vscode": "^1.100.0",
+        "@types/vscode": "1.92.0",
         "@vitest/ui": "^3.1.3",
         "@vscode/vsce": "^3.3.2",
         "@wdio/cli": "^9.13.0",
@@ -45,7 +45,7 @@
         "wdio-vscode-service": "^6.0.3"
       },
       "engines": {
-        "vscode": "^1.80.0"
+        "vscode": "^1.92.0"
       }
     },
     "node_modules/@algorandfoundation/algokit-avm-debugger": {
@@ -3122,9 +3122,9 @@
       "license": "MIT"
     },
     "node_modules/@types/vscode": {
-      "version": "1.100.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.100.0.tgz",
-      "integrity": "sha512-4uNyvzHoraXEeCamR3+fzcBlh7Afs4Ifjs4epINyUX/jvdk0uzLnwiDY35UKDKnkCHP5Nu3dljl2H8lR6s+rQw==",
+      "version": "1.92.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.92.0.tgz",
+      "integrity": "sha512-DcZoCj17RXlzB4XJ7IfKdPTcTGDLYvTOcTNkvtjXWF+K2TlKzHHkBEXNWQRpBIXixNEUgx39cQeTFunY0E2msw==",
       "dev": true,
       "license": "MIT"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@types/lodash": "^4.17.7",
         "@types/mocha": "^10.0.7",
         "@types/node": "^18.18.11",
-        "@types/vscode": "1.92.0",
+        "@types/vscode": "~1.92.0",
         "@vitest/ui": "^3.1.3",
         "@vscode/vsce": "^3.3.2",
         "@wdio/cli": "^9.13.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@types/lodash": "^4.17.7",
     "@types/mocha": "^10.0.7",
     "@types/node": "^18.18.11",
-    "@types/vscode": "1.92.0",
+    "@types/vscode": "~1.92.0",
     "@vitest/ui": "^3.1.3",
     "@vscode/vsce": "^3.3.2",
     "@wdio/cli": "^9.13.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "smart contract debugger"
   ],
   "engines": {
-    "vscode": "^1.80.0"
+    "vscode": "^1.92.0"
   },
   "icon": "./images/icon.png",
   "categories": [
@@ -62,7 +62,7 @@
     "@types/lodash": "^4.17.7",
     "@types/mocha": "^10.0.7",
     "@types/node": "^18.18.11",
-    "@types/vscode": "^1.100.0",
+    "@types/vscode": "1.92.0",
     "@vitest/ui": "^3.1.3",
     "@vscode/vsce": "^3.3.2",
     "@wdio/cli": "^9.13.0",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -96,7 +96,7 @@ export async function getSimulateTrace(filePath: string): Promise<algosdk.models
   }
   try {
     return algosdk.decodeJSON(JSON.stringify(traceFileContent), algosdk.modelsv2.SimulateResponse)
-  } catch (e) {
+  } catch {
     return tryParseAlgosdkV2SimulateResponse(traceFileContent)
   }
 }
@@ -289,7 +289,7 @@ export const readFileAsJson = async <T>(fsPath: string) => {
   try {
     const bytes = await workspaceFileAccessor.readFile(fsPath)
     return JSON.parse(new TextDecoder().decode(bytes)) as T
-  } catch (_e) {
+  } catch {
     return undefined
   }
 }


### PR DESCRIPTION
pin `@types/vscode` version to 1.92 and upgrade min VS Code version to 1.92.0.

Version 1.92 was chosen instead of 1.80.0 because:
- The `package-lock.json` has been targeting 1.92 for a while. Downgrading to 1.80.0 requires fixing compile issues.
  -  [… to 1.92.0](https://github.com/algorandfoundation/algokit-avm-vscode-debugger/blob/4a740db9de3ced304bfb4d40888b4acfd8b1f05a/package-lock.json#L2421)
- Version 1.92 was released July 2024, more than 1 year old. I think we don't need to support older version than that, considering VS Code provides auto update.
