### PR TITLE
fix: simulate trace json parsing issue with large uint64 values

### DIFF
--- a/examples/multiRootWorkspace/large-uint64/debug_traces/simulate-response.trace.avm.json
+++ b/examples/multiRootWorkspace/large-uint64/debug_traces/simulate-response.trace.avm.json
@@ -1,0 +1,51 @@
+{
+  "exec-trace-config": {
+    "enable": true,
+    "scratch-change": true,
+    "stack-change": true,
+    "state-change": true
+  },
+  "last-round": 61132879,
+  "txn-groups": [
+    {
+      "app-budget-added": 700,
+      "app-budget-consumed": 23,
+      "txn-results": [
+        {
+          "app-budget-consumed": 23,
+          "exec-trace": {
+            "approval-program-hash": "zu7nlC89alo0DQFE0YGHn3RvvvTyHmpu1t6el3K+boc=",
+            "approval-program-trace": [
+              {
+                "pc": 40,
+                "stack-additions": [
+                  {
+                    "type": 2,
+                    "uint": 18446744073709551227
+                  }
+                ]
+              }
+            ]
+          },
+          "txn-result": {
+            "txn": {
+              "sig": "KEj30pqis5bgB17y83+X0rzyuQZzw6lGWwfktma8nnygDz6zbObxC0Mn9g88j4qiozerUEAtgUam6Oaqd/4iBg==",
+              "txn": {
+                "apaa": ["b25fdXBkYXRl", "MTYyNC45MjE0NzU2ODQ0MjAwMDAw", "MC4yNjg4MzAyMDE4NDE2MTAw"],
+                "apid": 3494126405,
+                "fee": 1000,
+                "fv": 61132878,
+                "gen": "mainnet-v1.0",
+                "gh": "wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=",
+                "lv": 61133878,
+                "snd": "N6JZYPCU22PWORVZPOZEDAZO6OEYRSRVAVJGDNDKWGVHM37YHJJJK4554Q",
+                "type": "appl"
+              }
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "version": 2
+}

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -40,6 +40,7 @@ describe('Should successfully parse simulate traces', () => {
     ['errors/debug_traces/app.trace.avm.json'],
     ['errors/debug_traces/app-from-logicsig.trace.avm.json'],
     ['errors/debug_traces/inner-app-overspend.trace.avm.json'],
+    ['large-uint64/debug_traces/simulate-response.trace.avm.json'],
   ])('should successfully parse simulate trace from %s', async (filePath) => {
     // Setup
     const fullPath = path.join(__dirname, '..', 'examples', 'multiRootWorkspace', filePath)
@@ -54,5 +55,21 @@ describe('Should successfully parse simulate traces', () => {
     expect(Array.isArray(result?.txnGroups)).toBe(true)
     expect(result?.txnGroups.length).toBeGreaterThan(0)
     expect(result?.execTraceConfig).toBeDefined()
+  })
+
+  it('should preserve large uint64 values without truncating them to unsafe integers', async () => {
+    // Regression test for https://github.com/algorandfoundation/algokit-avm-vscode-debugger/issues/109
+    const fullPath = path.join(
+      __dirname,
+      '..',
+      'examples',
+      'multiRootWorkspace',
+      'large-uint64/debug_traces/simulate-response.trace.avm.json',
+    )
+
+    const result = await getSimulateTrace(fullPath)
+
+    const stackAddition = result?.txnGroups[0].txnResults[0].execTrace?.approvalProgramTrace?.[0].stackAdditions?.[0]
+    expect(stackAddition?.uint).toBe(18446744073709551227n)
   })
 })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,11 +1,11 @@
 import { ProgramSourceEntryFile } from '@algorandfoundation/algokit-avm-debugger'
-import { encodeAddress, base64ToBytes, bytesToBase64 as utilsBytesToBase64 } from '@algorandfoundation/algokit-utils/common'
-import { LogicSig } from '@algorandfoundation/algokit-utils/transact'
 import {
   SimulateResponse,
   SimulationTransactionExecTrace,
   decodeSimulateResponseFromJson,
 } from '@algorandfoundation/algokit-utils/algod-client'
+import { base64ToBytes, encodeAddress, parseJson, bytesToBase64 as utilsBytesToBase64 } from '@algorandfoundation/algokit-utils/common'
+import { LogicSig } from '@algorandfoundation/algokit-utils/transact'
 import { orderBy, take } from 'lodash'
 import * as vscode from 'vscode'
 import { MAX_FILES_TO_SHOW, NO_WORKSPACE_ERROR_MESSAGE } from './constants'
@@ -57,11 +57,17 @@ function tryParseSimulateResponse(rawSimulateTrace: Record<string, unknown>): Si
 }
 
 export async function getSimulateTrace(filePath: string): Promise<SimulateResponse | null> {
-  const traceFileContent = await readFileAsJson<Record<string, unknown>>(filePath)
-  if (!traceFileContent) {
+  // read the raw file content and parse it with bigint-aware decoding
+  // otherwise we might botch large uint64 numbers
+  let traceFileContent: Record<string, unknown>
+  try {
+    const bytes = await workspaceFileAccessor.readFile(filePath)
+    traceFileContent = parseJson(new TextDecoder().decode(bytes))
+  } catch {
     vscode.window.showErrorMessage(`Could not open the simulate trace file at path "${filePath}".`)
     return null
   }
+
   try {
     return decodeSimulateResponseFromJson(traceFileContent)
   } catch {


### PR DESCRIPTION
This PR fixes #109 
The parsing of simulate traces would break on large `uint64`.
Switched to using utils `parseJson` specifically for simulate traces.